### PR TITLE
Update the crate name to cobalt-aws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Initial release of the `hai-aws` crate.
+- Initial release of the `cobalt-aws` crate.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "hai-aws"
+name = "cobalt-aws"
 version = "0.1.0"
 authors = ["harrison.ai Data Engineering <dataengineering@harrison.ai>"]
 edition = "2021"
 description = "This library provides a collection of wrappers around the aws-sdk-rust packages."
-repository = "https://github.com/harrison-ai/hai-aws/"
+repository = "https://github.com/harrison-ai/cobalt-aws/"
 license = "Apache-2.0"
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# The harrison.ai AWS wrapper library
+# The Cobalt AWS wrapper library
 
 This library provides a collection of wrappers around the [aws-sdk-rust](https://github.com/awslabs/aws-sdk-rust) packages.
 
 These wrappers are intended to make it easier to perform common tasks when developing applications which run on AWS infrastructure.
 
-* [Changelog](https://github.com/harrison-ai/hai-aws/CHANGELOG.md)
-* [Documentation](https://docs.rs/hai-aws)
+* [Changelog](https://github.com/harrison-ai/cobalt-aws/CHANGELOG.md)
+* [Documentation](https://docs.rs/cobalt-aws)
 
 ### About harrison.ai
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! # The harrison.ai AWS wrapper library
+//! # The Cobalt AWS wrapper library
 //!
 //! This library provides a collection of wrappers around the
 //! [aws-sdk-rust](https://github.com/awslabs/aws-sdk-rust) packages.
@@ -6,7 +6,7 @@
 //! These wrappers are intended to make it easier to perform common
 //! tasks when developing applications which run on AWS infrastructure.
 //!
-//! * [Changelog](https://github.com/harrison-ai/hai-aws/CHANGELOG.md)
+//! * [Changelog](https://github.com/harrison-ai/cobalt-aws/CHANGELOG.md)
 //!
 //! ### About harrison.ai
 //!

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -15,7 +15,7 @@ pub use aws_sdk_s3::Client;
 ///
 /// ```
 /// use aws_config;
-/// use hai_aws::s3::get_client;
+/// use cobalt_aws::s3::get_client;
 ///
 /// # tokio_test::block_on(async {
 /// let shared_config = aws_config::load_from_env().await;


### PR DESCRIPTION
## What

Changes the crate name from `hai-aws` to `cobalt-aws`.

## Why

The `hai` prefix was simultaneously not very meaningful to most people, hard to say, and placed more emphasis on harrison.ai as the maintainers of the package than we want. "Cobalt" is more generic and memorable, while maintaining an allusion to the brand colours of harrison.ai.

## Notes

We'll also rename the repository as part of this change.