### PR TITLE
Prepare for initial release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
+
+ -
+
+## 0.1.0
 
 - Initial release of the `cobalt-aws` crate.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,15 @@ edition = "2021"
 description = "This library provides a collection of wrappers around the aws-sdk-rust packages."
 repository = "https://github.com/harrison-ai/cobalt-aws/"
 license = "Apache-2.0"
-publish = false
+publish = true
+include = [
+    "Cargo.toml",
+    "src/*",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENCE",
+]
+
 
 [dependencies]
 anyhow = "1.0.53"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,25 @@
+## Release Process
+
+To make a release of `cobalt-aws`, follow these steps:
+
+1. Prepare a release PR:
+   -  Update the version in Cargo.toml to the target version
+   -  Update the Changelog by changing the "Unreleased" heading to the target version and creating a blank Unrelease section
+   -  Review the PR history since the previous release and ensure the changelog contents are up to date and correct.
+3. Push PR and merge into `main`
+   - Trigger publish from Github actions (TODO), or
+   - Pull from `main` and publish from local
+   - `cargo login <token>`
+   - `cargo publish --dry-run`
+   - `cargo package --list`
+   - `cargo publish`
+5. Tag a release on github from https://github.com/harrison-ai/cobalt-aws/releases/new
+   - the tag should be in the form v1.2.3
+   - The release title should include the version and the human readable date, e.g. "1.2.3 (January 1, 2022)"
+   - The release notes should generally be a cut/paste from the Changelog.
+
+Reference: https://doc.rust-lang.org/cargo/reference/publishing.html
+
+## Note
+
+These instructions are a work in progress, we will be refining and automating them as we go.


### PR DESCRIPTION
## What

This PR prepares the repo for its initial publish to crates.io. This includes marking the package as public, updating the `includes` field in the `Cargo.toml` to only publish what's appropriate, and adding some notes on the process to follow to publish a new package version (to the best of our current understanding).

## Why

We're ready for this initial version to go live!

## Notes

We'll also be marking this repo as `public` before pushing to crates.io.