### PR TITLE
Move test-only deps into dev-dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
- -
+ - Moved test dependencies into `dev-dependencies`.
 
 ## 0.1.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ anyhow = "1.0.53"
 aws-config = "0.6.0"
 aws-sdk-s3 = "0.6.0"
 http = "0.2.6"
-serial_test = "0.5.1"
 tokio = { version = "1.16.1", features=["macros"] }
+
+[dev-dependencies]
+serial_test = "0.5.1"
 tokio-test = "0.4.2"


### PR DESCRIPTION
## What

Move some deps into `dev-dependencies`. Ref: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#development-dependencies

## Why

We don't need people to pull these libraries when they use our library.
