### PR TITLE
Add lambda::run_message_handler function

### DIFF
--- a/.github/workflows/localstack.yml
+++ b/.github/workflows/localstack.yml
@@ -1,0 +1,28 @@
+name: Run LocalStack tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  localstsack:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Start LocalStack
+        env:
+          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+        run: |
+          # install LocalStack cli and awslocal
+          pip install localstack awscli-local[ver1]
+          # Make sure to pull the latest version of the image
+          docker pull localstack/localstack:0.14.0
+      - name: Run hello world example
+        run: |
+          # TODO: This script currently runs without a failure, however
+          # it is not generating the logs we expect. This needs further investigation.
+          ./scripts/run_example.sh
+          sleep 5
+          ./scripts/read_logs.sh

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ target
 
 # https://doc.rust-lang.org/cargo/faq.html#why-do-binaries-have-cargolock-in-version-control-but-not-libraries
 Cargo.lock
+
+# Generated when running examples
+lambda.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+ - Add `lambda::run_message_handler()`, which simlifies the task of writing a Lambda function which is triggered by an SQS event source mapping.
  - Moved test dependencies into `dev-dependencies`.
 
 ## 0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
- - Add `lambda::run_message_handler()`, which simlifies the task of writing a Lambda function which is triggered by an SQS event source mapping.
+ - Add `lambda::run_message_handler()`, which simplifies the task of writing a Lambda function which is triggered by an SQS event source mapping.
  - Moved test dependencies into `dev-dependencies`.
 
 ## 0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "cobalt-aws"
 version = "0.1.0"
 authors = ["harrison.ai Data Engineering <dataengineering@harrison.ai>"]
 edition = "2021"
-description = "This library provides a collection of wrappers around the aws-sdk-rust packages."
+description = "This library provides a collection of wrappers around the aws-sdk-rust and lambda_runtime packages."
 repository = "https://github.com/harrison-ai/cobalt-aws/"
 license = "Apache-2.0"
 publish = true
@@ -15,13 +15,20 @@ include = [
     "LICENCE",
 ]
 
-
 [dependencies]
 anyhow = "1.0.54"
+async-trait = "0.1.52"
 aws-config = "0.6.0"
 aws-sdk-s3 = "0.6.0"
+aws_lambda_events = "0.5.0"
+clap = { version = "3.0.14", features = ["derive", "env"] }
 http = "0.2.6"
+lambda_runtime = "0.5.0"
+serde = "1.0.136"
+serde_json = "1.0.78"
 tokio = { version = "1.17.0", features=["macros"] }
+tracing = "0.1.29"
+tracing-subscriber = { version = "0.3.7", features=["json", "env-filter"] }
 
 [dev-dependencies]
 serial_test = "0.6.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Cobalt AWS wrapper library
 
-This library provides a collection of wrappers around the [aws-sdk-rust](https://github.com/awslabs/aws-sdk-rust) packages.
+This library provides a collection of wrappers around the [aws-sdk-rust](https://github.com/awslabs/aws-sdk-rust) and [lambda_runtime](https://github.com/awslabs/aws-lambda-rust-runtime) packages.
 
 These wrappers are intended to make it easier to perform common tasks when developing applications which run on AWS infrastructure.
 

--- a/deny.toml
+++ b/deny.toml
@@ -7,8 +7,9 @@ unmaintained = "warn"
 yanked = "warn"
 notice = "warn"
 ignore = [
-    # Like this:
-    #"RUSTSEC-YYYY-NNNN",
+    # time/chrono problems, have not been a problem in practice
+    "RUSTSEC-2020-0159",
+    "RUSTSEC-2020-0071",
 ]
 
 [licenses]

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-This directory contains a number of examples which demostrate the use of the `cobalt_aws::lambda` module.
+This directory contains a number of examples which demonstrate the use of the `cobalt_aws::lambda` module.
 
 To run these examples local, you will need to have [LocalStack installed](EXAMPLE). You can then run the script:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,16 @@
+# Examples
+
+This directory contains a number of examples which demostrate the use of the `cobalt_aws::lambda` module.
+
+To run these examples local, you will need to have [LocalStack installed](EXAMPLE). You can then run the script:
+
+
+```shell
+./scripts/run_example.sh
+```
+
+To read the output logs of the lambda, run the script:
+
+```shell
+./scripts/read_logs.sh
+```

--- a/examples/hello_lambda/main.rs
+++ b/examples/hello_lambda/main.rs
@@ -1,0 +1,56 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use clap::Parser;
+use serde::Deserialize;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use cobalt_aws::lambda::{run_message_handler, Error, LambdaContext};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    run_message_handler(message_handler).await
+}
+
+/// The structure of the messages we expect to see on the queue.
+#[derive(Debug, Deserialize)]
+pub struct Message {
+    pub target: String,
+}
+
+/// Configuration we receive from environment variables.
+///
+/// Note: all fields should be tagged with the `#[clap(env)]` attribute.
+#[derive(Debug, Parser)]
+pub struct Env {
+    #[clap(env)]
+    pub greeting: String,
+}
+
+/// Shared context we build up before invoking the lambda runner.
+#[derive(Debug)]
+pub struct Context {
+    pub greeting: String,
+}
+
+#[async_trait]
+impl LambdaContext<Env> for Context {
+    /// Initialise a shared context object from which will be
+    /// passed to all instances of the message handler.
+    async fn from_env(env: &Env) -> Result<Context> {
+        Ok(Context {
+            greeting: env.greeting.clone(),
+        })
+    }
+}
+
+/// Process a single message from the SQS queue, within the given context.
+async fn message_handler(message: Message, context: Arc<Context>) -> Result<()> {
+    tracing::debug!("Message: {:?}", message);
+    tracing::debug!("Context: {:?}", context);
+
+    // Log a greeting to the target
+    tracing::info!("{}, {}!", context.greeting, message.target);
+
+    Ok(())
+}

--- a/examples/template/main.rs
+++ b/examples/template/main.rs
@@ -1,0 +1,37 @@
+//! A minimal template to use as a starting point when writing your lambda function.
+use anyhow::Result;
+use async_trait::async_trait;
+use clap::Parser;
+use cobalt_aws::lambda::{run_message_handler, Error, LambdaContext};
+use serde::Deserialize;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    run_message_handler(message_handler).await
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Message {}
+
+#[derive(Debug, Parser)]
+pub struct Env {}
+
+#[derive(Debug)]
+pub struct Context {}
+
+#[async_trait]
+impl LambdaContext<Env> for Context {
+    async fn from_env(env: &Env) -> Result<Context> {
+        tracing::info!("Env: {:?}", env);
+
+        Ok(Context {})
+    }
+}
+
+async fn message_handler(message: Message, context: Arc<Context>) -> Result<()> {
+    tracing::info!("Message: {:?}", message);
+    tracing::info!("Context: {:?}", context);
+
+    Ok(())
+}

--- a/scripts/read_logs.sh
+++ b/scripts/read_logs.sh
@@ -1,0 +1,8 @@
+export EXAMPLE=hello_lambda
+export DEFAULT_REGION=ap-southeast-2
+
+# Read the logs
+
+export GROUP_NAME=`awslocal logs describe-log-groups | jq -r '.logGroups[0].logGroupName'`
+export STREAM_NAME=`awslocal logs describe-log-streams --log-group-name $GROUP_NAME | jq -r '.logStreams[0].logStreamName'`
+awslocal logs get-log-events --log-group-name /aws/lambda/$EXAMPLE --log-stream-name "$STREAM_NAME" | jq

--- a/scripts/run_example.sh
+++ b/scripts/run_example.sh
@@ -1,0 +1,49 @@
+# Choose the example to run
+export EXAMPLE=hello_lambda
+
+# Setup the environment
+export ENV="GREETING=hello"
+
+# Specify the message to send to the lambda
+export MESSAGE="{\"target\": \"world\"}"
+
+export DEFAULT_REGION=ap-southeast-2
+
+# Restart the localstack daemon
+localstack stop
+localstack start -d --no-banner
+localstack wait
+
+# Setup the queue
+export QUEUE_NAME=test-queue
+awslocal sqs create-queue --queue-name="$QUEUE_NAME" --attributes '{ "VisibilityTimeout": "240" }' > /dev/null
+QUEUE_URL=$(awslocal sqs list-queues | jq -r '.QueueUrls[0]')
+QUEUE_ARN=$(awslocal sqs get-queue-attributes --queue-url="$QUEUE_URL" --attribute-names QueueArn | jq -r '.Attributes.QueueArn')
+export QUEUE_URL QUEUE_ARN
+
+# Build the app and bundle it into a zip file
+if [ -z "$CI" ]; then
+   cargo b --example $EXAMPLE --target x86_64-unknown-linux-musl
+   cp target/x86_64-unknown-linux-musl/debug/examples/$EXAMPLE bootstrap && zip lambda.zip bootstrap && rm bootstrap
+else
+   cargo b --example $EXAMPLE
+   cp target/debug/examples/$EXAMPLE bootstrap && zip lambda.zip bootstrap && rm bootstrap
+fi
+
+# Create a lambda function
+awslocal lambda create-function \
+   --function-name=$EXAMPLE \
+   --role=rn:aws:iam:local \
+   --zip-file=fileb://lambda.zip \
+   --environment "Variables={$ENV}" \
+   --runtime=provided > /dev/null
+
+# Create an event source mapping
+awslocal lambda create-event-source-mapping --function-name $EXAMPLE --event-source-arn "$QUEUE_ARN" > /dev/null
+
+# Send the message to the queue, triggering the lambda
+awslocal sqs send-message --queue-url "$QUEUE_URL" --message-body "$MESSAGE" > /dev/null
+
+echo
+echo "🚀 Message $MESSAGE sent to '$EXAMPLE'."
+echo "Run ./scripts/read_logs.sh to see the logs"

--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -1,0 +1,220 @@
+//! A wrapper around the [lambda_runtime](https://github.com/awslabs/aws-lambda-rust-runtime) crate.
+//!
+//! This wrapper provides wrappers to make it easier to write Lambda functions which consume message from
+//! an SQS queue configured with an [event source mapping](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventsourcemapping.html).
+
+use anyhow::{Context as _, Result};
+use async_trait::async_trait;
+use aws_lambda_events::event::sqs::SqsEvent;
+use clap::Parser;
+use lambda_runtime::{service_fn, LambdaEvent};
+use std::future::Future;
+use std::sync::Arc;
+use tracing_subscriber::filter::EnvFilter;
+
+/// Re-export of [lambda_runtime::Error](https://docs.rs/lambda_runtime/latest/lambda_runtime/type.Error.html).
+///
+// We provide this re-export so that the user doesn't need to have lambda_runtime as a direct dependency.
+pub use lambda_runtime::Error;
+
+/// A required trait of the `Context` type used by message handler functions in [run_message_handler].
+///
+/// All `Context` types must implement the implement the [LambdaContext::from_env] method for their corresponding `Env` type.
+#[async_trait]
+pub trait LambdaContext<Env>: Sized {
+    /// # Example
+    ///
+    /// ```no_run
+    /// use anyhow::Result;
+    /// use cobalt_aws::lambda::LambdaContext;
+    ///
+    /// # use async_trait::async_trait;
+    /// # #[derive(Debug)]
+    /// # pub struct Env {
+    /// #     pub greeting: String,
+    /// # }
+    /// #
+    /// /// Shared context we build up before invoking the lambda runner.
+    /// #[derive(Debug)]
+    /// pub struct Context {
+    ///     pub greeting: String,
+    /// }
+    ///
+    /// #[async_trait]
+    /// impl LambdaContext<Env> for Context {
+    ///     /// Initialise a shared context object from which will be
+    ///     /// passed to all instances of the message handler.
+    ///     async fn from_env(env: &Env) -> Result<Context> {
+    ///         Ok(Context {
+    ///             greeting: env.greeting.clone(),
+    ///         })
+    ///     }
+    /// }
+    /// ```
+    async fn from_env(env: &Env) -> Result<Self>;
+}
+
+/// Executes a message handler against all the message received in a batch
+/// from an SQS event source mapping.
+///
+/// The `run_message_handler` function takes care of the following tasks:
+///
+/// * Executes the Lambda runtime, using [lambda_runtime](https://github.com/awslabs/aws-lambda-rust-runtime).
+/// * Sets up tracing to ensure all `tracing::<...>!()` calls are JSON formatted for consumption by CloudWatch.
+/// * Processes environment variables and makes them available to your handler
+/// * Initialises a shared context object, which is passed to your handler.
+/// * Deserialises a batch of messages and passes each one to your handler.
+///
+/// ## Writing a message handler
+///
+/// To write a message handler, you need to define four elements:
+///
+/// * The `Message` structure, which defines the structure of the messages which will be sent to the SQS
+///    queue, and then forwarded on to your Lambda.
+/// * The `Env` structure, which defines the expected environment variables your Lambda will receive.
+/// * The `Context` structure, which is provided the `Env` structure, and represents the shared state
+///   that will be passed into your message handler. This structure needs to implement the [LambdaContext] trait.
+/// * The `message_handler` function, which accepts a `Message` and a `Context`, and performs the desired actions.
+///
+/// # Example
+///
+/// ```no_run
+/// use anyhow::Result;
+/// use async_trait::async_trait;
+/// use clap::Parser;
+/// use serde::Deserialize;
+/// use std::fmt::Debug;
+/// use std::sync::Arc;
+///
+/// use cobalt_aws::lambda::{run_message_handler, Error, LambdaContext};
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Error> {
+///     run_message_handler(message_handler).await
+/// }
+///
+/// /// The structure of the messages we expect to see on the queue.
+/// #[derive(Debug, Deserialize)]
+/// pub struct Message {
+///     pub target: String,
+/// }
+///
+/// /// Configuration we receive from environment variables.
+/// ///
+/// /// Note: all fields should be tagged with the `#[clap(env)]` attribute.
+/// #[derive(Debug, Parser)]
+/// pub struct Env {
+///     #[clap(env)]
+///     pub greeting: String,
+/// }
+///
+/// /// Shared context we build up before invoking the lambda runner.
+/// #[derive(Debug)]
+/// pub struct Context {
+///     pub greeting: String,
+/// }
+///
+/// #[async_trait]
+/// impl LambdaContext<Env> for Context {
+///     /// Initialise a shared context object from which will be
+///     /// passed to all instances of the message handler.
+///     async fn from_env(env: &Env) -> Result<Context> {
+///         Ok(Context {
+///             greeting: env.greeting.clone(),
+///         })
+///     }
+/// }
+///
+/// /// Process a single message from the SQS queue, within the given context.
+/// async fn message_handler(message: Message, context: Arc<Context>) -> Result<()> {
+///     tracing::debug!("Message: {:?}", message);
+///     tracing::debug!("Context: {:?}", context);
+///
+///     // Log a greeting to the target
+///     tracing::info!("{}, {}!", context.greeting, message.target);
+///
+///     Ok(())
+/// }
+/// ```
+///
+/// # Error handling
+///
+/// If any errors are raised during init, or from the `message_handler` function, then the entire message
+/// batch will be considered to have failed. Error messages will be logged in CloudWatch, and the message batch
+/// being processed will be returned to the original queue.
+pub async fn run_message_handler<F, Fut, Msg, Context, Env>(message_handler: F) -> Result<(), Error>
+where
+    F: Fn(Msg, Arc<Context>) -> Fut,
+    Fut: Future<Output = Result<()>>,
+    Msg: serde::de::DeserializeOwned,
+    Context: LambdaContext<Env> + std::fmt::Debug,
+    Env: Parser + std::fmt::Debug,
+{
+    // Perform initial setup outside of the runtime to avoid this code being run
+    // on every invocation of the lambda.
+    //
+    // Ideally an error in this code would cause the runtime to return an initialization error:
+    // https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html#runtimes-api-initerror
+    // however this isn't currently supported by `lambda_runtime` (perhaps an area
+    // for future work). To work around this, we capture any errors during this phase
+    // and pass them into the handler function itself, so that it can raise the error
+    // when the function is invoked.
+    let init_result = (|| async {
+        // Setup tracing
+        tracing_subscriber::fmt()
+            .with_env_filter(
+                EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+            )
+            .json()
+            .init();
+        let env =
+            Env::try_parse().context("An error occurred while parsing environment variables.")?;
+        let ctx = Arc::new(Context::from_env(&env).await?);
+        tracing::info!("Env: {:?}", env);
+        tracing::info!("Context: {:?}", ctx);
+        Ok::<_, anyhow::Error>(ctx)
+    })()
+    .await;
+
+    lambda_runtime::run(service_fn(|event: LambdaEvent<SqsEvent>| async {
+        let (event, _context) = event.into_parts();
+        // Process the event and capture any errors
+        let result = (|| async {
+            // Check the result of the init phase. If it failed, log the message
+            // and immediately return.
+            let ctx = match &init_result {
+                Ok(x) => x,
+                Err(e) => {
+                    tracing::error!("{:?}", e);
+                    return Err(anyhow::anyhow!("Failed to initialise lambda."));
+                }
+            };
+
+            // Process each of the records. If any of them fail, return immediately.
+            for record in event.records {
+                let body = record
+                    .body
+                    .as_ref()
+                    .with_context(|| format!("No SqsMessage body: {:?}", record))?;
+                let msg = serde_json::from_str::<Msg>(body)
+                    .with_context(|| format!("Error parsing body into message: {}", body))?;
+                message_handler(msg, ctx.clone())
+                    .await
+                    .with_context(|| format!("Error running message handler: {}", body))?;
+            }
+            Ok(())
+        })()
+        .await;
+
+        // Log out the full error, as the lambda_runtime only logs the first line of the error
+        // message, which can hide crucial information.
+        match result {
+            Ok(_) => result,
+            Err(e) => {
+                tracing::error!("{:?}", e);
+                Err(anyhow::anyhow!("Failed to process SQS event."))
+            }
+        }
+    }))
+    .await
+}

--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -54,7 +54,7 @@ pub trait LambdaContext<Env>: Sized {
     async fn from_env(env: &Env) -> Result<Self>;
 }
 
-/// Executes a message handler against all the message received in a batch
+/// Executes a message handler against all the messages received in a batch
 /// from an SQS event source mapping.
 ///
 /// The `run_message_handler` function takes care of the following tasks:
@@ -140,8 +140,8 @@ pub trait LambdaContext<Env>: Sized {
 /// # Error handling
 ///
 /// If any errors are raised during init, or from the `message_handler` function, then the entire message
-/// batch will be considered to have failed. Error messages will be logged in CloudWatch, and the message batch
-/// being processed will be returned to the original queue.
+/// batch will be considered to have failed. Error messages will be logged to stdout in a format compatible
+/// with CloudWatch, and the message batch being processed will be returned to the original queue.
 pub async fn run_message_handler<F, Fut, Msg, Context, Env>(message_handler: F) -> Result<(), Error>
 where
     F: Fn(Msg, Arc<Context>) -> Fut,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 //! # The Cobalt AWS wrapper library
 //!
 //! This library provides a collection of wrappers around the
-//! [aws-sdk-rust](https://github.com/awslabs/aws-sdk-rust) packages.
+//! [aws-sdk-rust](https://github.com/awslabs/aws-sdk-rust) and
+//! [lambda_runtime](https://github.com/awslabs/aws-lambda-rust-runtime) packages.
 //!
 //! These wrappers are intended to make it easier to perform common
 //! tasks when developing applications which run on AWS infrastructure.
@@ -18,6 +19,7 @@
 
 // Public modules
 
+pub mod lambda;
 pub mod s3;
 
 // Internal shared modules


### PR DESCRIPTION
## What

This PR adds a wrapper around the `lambda_runtime` package to make it easier to write lambda functions which are triggered by event source mappings to an SQS queue.

## Why

There is a certain amount of boiler-plate which is often recreated when setting up a lambda function. In general the process of iterating over the message batch and handling errors, etc, is not a problem we want to solve each time we write a lambda.

## Concerns

This implementation is an MVP version of this feature. A couple of missing features that will be added in future iterations are:
 * Batch item error handling, so that individual failures of a message don't cause the entire batch to fail.
 * A "reduce" step, to collect return values across the messages and then apply a function to the collected results.
 * (?) Access to the raw `SqsMessage`.

Testing of this feature requires external integration testing. The script runners in the `scripts` directory allow the examples to run locally against LocalStack. I've put in place a github action to run these scripts, but so far I'm not able to access the generated logs. I've spent quite some time debugging this, so for now I'm going to park that effort in favour of shipping what we have. Getting external integration tests running properly will be a task for a separate PR.