### PR TITLE
chore: Check lambda init result once, rather than every time.

### DIFF
--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -7,8 +7,6 @@ use anyhow::{Context as _, Result};
 use async_trait::async_trait;
 use aws_lambda_events::event::sqs::SqsEvent;
 use clap::Parser;
-use futures::stream::{self, StreamExt, TryStreamExt};
-use futures::FutureExt;
 use lambda_runtime::{service_fn, LambdaEvent};
 use std::ffi::OsString;
 use std::future::Future;


### PR DESCRIPTION
## What

Rather than checking the result of initialisation on every invocation of the lambda, check it once and register a specialized "failure handler" or "success handler".

## Why

It moves the check out of the invocation loop, for what I'm sure is a completely un-measurable performance boost. Mostly this was something that I was wondering about when reviewing #9 and I wanted to see what it would look like. I think it looks OK, although YMMV.

