### PR TITLE
Add s3::list_objects to stream an object listing from a bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ Cargo.lock
 
 # Generated when running examples
 lambda.zip
+
+# Generated when initialising localstack
+test-data/multi-page

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ aws-config = "0.7.0"
 aws-sdk-s3 = "0.7.0"
 aws_lambda_events = "0.6.0"
 clap = { version = "3.1.1", features = ["derive", "env"] }
+futures = "0.3.21"
 http = "0.2.6"
 lambda_runtime = "0.5.0"
 serde = "1.0.136"
@@ -31,5 +32,6 @@ tracing = "0.1.31"
 tracing-subscriber = { version = "0.3.9", features=["json", "env-filter"] }
 
 [dev-dependencies]
+reqwest = { version = "0.11.9", features=["json"] }
 serial_test = "0.6.0"
 tokio-test = "0.4.2"

--- a/deny.toml
+++ b/deny.toml
@@ -36,6 +36,15 @@ license-files = [
     { path = "LICENSE", hash = 0xbd0eed23 }
 ]
 
+# https://github.com/hsivonen/encoding_rs#licensing
+[[licenses.clarify]]
+name = "encoding_rs"
+version = "*"
+expression = "(Apache-2.0 OR MIT) AND BSD-3-Clause"
+license-files = [
+    { path = "COPYRIGHT", hash = 0x39f8ad31 }
+]
+
 [licenses.private]
 # So we don't have to declare a license on our own unpublished crates.
 ignore = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,28 @@ services:
       - '~/.cargo/registry:/usr/local/cargo/registry'
       - '.:/app'
     working_dir: '/app'
+    environment:
+      - LOCALSTACK_HOSTNAME=localstack
+      - AWS_DEFAULT_REGION=ap-southeast-2
+      - AWS_ACCESS_KEY_ID=placeholder
+      - AWS_SECRET_ACCESS_KEY=placeholder
+    depends_on:
+      - localstack
+
+  localstack:
+    image: localstack/localstack:0.14.0
+    ports:
+      - "4566:4566"
+    environment:
+      - SERVICES=${SERVICES-}
+      - DEBUG=0
+      - DATA_DIR=${DATA_DIR-}
+      - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR-}
+      - HOST_TMP_FOLDER=${TMPDIR:-/tmp/}localstack
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - AWS_DEFAULT_REGION=ap-southeast-2
+    volumes:
+      - "${TMPDIR:-/tmp}/localstack:/tmp/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "./scripts/init-localstack.sh:/docker-entrypoint-initaws.d/init-localstack.sh"
+      - "./test-data:/tmp/test-data"

--- a/scripts/init-localstack.sh
+++ b/scripts/init-localstack.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+printf "Configuring localstack components..."
+
+set -x
+
+# Any initialisation of the localstack infrastructure required for testing
+# should be set up in this script.
+
+## S3 tests
+awslocal s3 mb s3://empty-bucket
+
+# Add enough data to require multiple pages of data when listing the bucket
+mkdir -p /tmp/test-data/multi-page
+set +x
+for i in `seq -w 1 2500`
+do
+  cp /tmp/test-data/test.txt /tmp/test-data/multi-page/file-${i}.txt
+done
+set -x
+
+awslocal s3 mb s3://test-bucket
+awslocal s3 cp /tmp/test-data s3://test-bucket --recursive
+
+printf "Configuration done"

--- a/src/localstack.rs
+++ b/src/localstack.rs
@@ -24,49 +24,136 @@ pub(crate) fn get_endpoint_uri() -> Result<Option<Uri>> {
 }
 
 #[cfg(test)]
+pub mod test_utils {
+    use super::*;
+    use reqwest;
+    use serde::Deserialize;
+    use std::thread::sleep;
+    use std::time::{Duration, Instant};
+
+    #[derive(Deserialize, Debug)]
+    struct Health {
+        features: Option<Feature>,
+    }
+    #[derive(Deserialize, Debug)]
+    #[allow(non_snake_case)]
+    struct Feature {
+        initScripts: Option<String>,
+    }
+
+    /// This function polls the <localstack_url>/health endpoint and waits for the { features: initScripts } value to
+    /// be "initialized".
+    ///
+    /// We poll at one second intervals and timeout after 1 minute.
+    ///
+    /// This API doesn't seem to be publicly documented, but the code can be seen here:
+    ///
+    /// https://github.com/localstack/localstack/blob/b21178e1d62bfd784058496ac9d34d91c11bd329/bin/docker-entrypoint.sh#L54
+    ///
+    /// See also: https://github.com/localstack/localstack/pull/4770/files
+    ///
+    /// # Panic
+    ///
+    /// This function will panic on any kind of failure
+    pub async fn wait_for_localstack() {
+        // If tests are being run locally (e.g. not from within docker) then we
+        // expect localstack to be available at localhost:4566.
+        if env::var("LOCALSTACK_HOSTNAME").is_err() {
+            env::set_var("LOCALSTACK_HOSTNAME", "localhost");
+        }
+        // Our local stack configuration is setup to run as ap-southeast-2,
+        // so we explicitly set this here.
+        env::set_var("AWS_DEFAULT_REGION", "ap-southeast-2");
+
+        let uri = get_endpoint_uri().unwrap().unwrap();
+        let now = Instant::now();
+        loop {
+            match reqwest::get(&format!("{:?}health", uri)).await {
+                Err(_) => {
+                    println!("Localstack URL: {:#?}", uri);
+                    panic!("Unable to connect to localstack. To run localstack locally, run `docker-compose up -d`");
+                }
+                Ok(response) => {
+                    let health: Health = response.json().await.unwrap();
+                    if let Some(features) = health.features {
+                        if let Some(s) = features.initScripts {
+                            if s == "initialized" {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            if now.elapsed().as_secs() > 60 {
+                println!("Localstack URL: {:#?}", uri);
+                panic!("Timed out while waiting for localstack to initialise!")
+            }
+            sleep(Duration::new(1, 0));
+        }
+    }
+}
+
+#[cfg(test)]
 mod test {
     use super::*;
 
     use serial_test::serial;
 
+    /// Run get_endpoint_uri() with a given host and port in the environment, resetting
+    /// the environment to its original state afterwards.
+    fn safe_get_endpoint_uri(host: Option<String>, port: Option<String>) -> Result<Option<Uri>> {
+        let orig_host = env::var("LOCALSTACK_HOSTNAME");
+        let orig_port = env::var("EDGE_PORT");
+
+        match host {
+            Some(host) => env::set_var("LOCALSTACK_HOSTNAME", host),
+            None => env::remove_var("LOCALSTACK_HOSTNAME"),
+        }
+
+        match port {
+            Some(port) => env::set_var("EDGE_PORT", port),
+            None => env::remove_var("EDGE_PORT"),
+        }
+
+        let uri = get_endpoint_uri();
+
+        match orig_host {
+            Ok(host) => env::set_var("LOCALSTACK_HOSTNAME", host),
+            Err(_) => env::remove_var("LOCALSTACK_HOSTNAME"),
+        }
+        match orig_port {
+            Ok(port) => env::set_var("EDGE_PORT", port),
+            Err(_) => env::remove_var("EDGE_PORT"),
+        }
+
+        uri
+    }
+
     #[test]
     #[serial]
     fn test_get_localstack_endpoint_empty() {
-        let uri = get_endpoint_uri().unwrap();
+        let uri = safe_get_endpoint_uri(None, None).unwrap();
         assert_eq!(uri, None);
     }
 
     #[test]
     #[serial]
     fn test_get_localstack_endpoint_host() {
-        env::set_var("LOCALSTACK_HOSTNAME", "test_hostname");
-        let uri = get_endpoint_uri().unwrap();
-        env::remove_var("LOCALSTACK_HOSTNAME");
-
+        let uri = safe_get_endpoint_uri(Some("test_hostname".into()), None).unwrap();
         assert_eq!(uri, Some(Uri::from_static("http://test_hostname:4566")));
     }
 
     #[test]
     #[serial]
     fn test_get_localstack_endpoint_host_port() {
-        env::set_var("LOCALSTACK_HOSTNAME", "test_hostname");
-        env::set_var("EDGE_PORT", "1234");
-        let uri = get_endpoint_uri().unwrap();
-        env::remove_var("LOCALSTACK_HOSTNAME");
-        env::remove_var("EDGE_PORT");
-
+        let uri = safe_get_endpoint_uri(Some("test_hostname".into()), Some("1234".into())).unwrap();
         assert_eq!(uri, Some(Uri::from_static("http://test_hostname:1234")));
     }
 
     #[test]
     #[serial]
     fn test_get_localstack_endpoint_bad_uri() {
-        env::set_var("LOCALSTACK_HOSTNAME", "bad:host");
-        env::set_var("EDGE_PORT", "not-a-number");
-        let uri = get_endpoint_uri();
-        env::remove_var("LOCALSTACK_HOSTNAME");
-        env::remove_var("EDGE_PORT");
-
+        let uri = safe_get_endpoint_uri(Some("bad:host".into()), Some("not-a-number".into()));
         match uri {
             Ok(uri) => Err(format!("Expected error, recieved {:?}", uri)),
             Err(e) => {

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -1,7 +1,11 @@
 //! A collection of wrappers around the [aws_sdk_s3](https://docs.rs/aws-sdk-s3/latest/aws_sdk_s3/) crate.
 
 use anyhow::Result;
-use aws_sdk_s3::{config, Endpoint};
+use aws_sdk_s3::error::ListObjectsV2Error;
+use aws_sdk_s3::types::SdkError;
+use aws_sdk_s3::{config, model, Endpoint};
+use futures::stream;
+use futures::stream::{Stream, TryStreamExt};
 
 use crate::localstack;
 
@@ -54,18 +58,193 @@ pub fn get_client(shared_config: &aws_config::Config) -> Result<Client> {
     Ok(Client::from_conf(builder.build()))
 }
 
+/// Perform a bucket listing, returning a stream of results.
+///
+/// # Example
+///
+/// ```no_run
+/// use aws_config;
+/// use cobalt_aws::s3::{get_client, list_objects};
+/// use futures::TryStreamExt;
+///
+/// # tokio_test::block_on(async {
+/// let shared_config = aws_config::load_from_env().await;
+/// let client = get_client(&shared_config).unwrap();
+/// let mut objects = list_objects(&client, "my-bucket", Some("prefix".into()));
+/// while let Some(item) = objects.try_next().await.unwrap() {
+///     println!("{:?}", item);
+/// }
+/// # })
+/// ```
+///
+///  # Implementation details
+///
+/// This function uses the [ListObjectsV2](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html)
+/// API and performs pagination to ensure all objects are returned.
+pub fn list_objects(
+    client: &Client,
+    bucket: impl Into<String>,
+    prefix: Option<String>,
+) -> impl Stream<Item = Result<model::Object, SdkError<ListObjectsV2Error>>> + Unpin {
+    let req = client
+        .list_objects_v2()
+        .bucket(bucket)
+        .set_prefix(prefix)
+        .into_paginator();
+    req.send()
+        .map_ok(|list_objs| {
+            stream::iter(
+                list_objs
+                    .contents
+                    .unwrap_or_default() // An empty bucket comes back as None, rather than an empty vector
+                    .into_iter()
+                    .map(Ok),
+            )
+        })
+        .try_flatten()
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
 
     use aws_config;
+    use futures::TryStreamExt;
     use serial_test::serial;
+    use std::error::Error;
     use tokio;
 
     #[tokio::test]
     #[serial]
     async fn test_get_client() {
-        let config = aws_config::load_from_env().await;
-        get_client(&config).unwrap();
+        let shared_config = aws_config::load_from_env().await;
+        get_client(&shared_config).unwrap();
+    }
+
+    async fn localstack_test_client() -> Client {
+        localstack::test_utils::wait_for_localstack().await;
+        let shared_config = aws_config::load_from_env().await;
+        get_client(&shared_config).unwrap()
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_non_existant_bucket() {
+        let client = localstack_test_client().await;
+
+        let stream = list_objects(&client, "non-existant-bucket", None);
+        let e = stream.try_collect::<Vec<_>>().await.unwrap_err();
+        assert!(matches!(
+            e.source()
+                .unwrap()
+                .downcast_ref::<ListObjectsV2Error>()
+                .unwrap()
+                .kind,
+            aws_sdk_s3::error::ListObjectsV2ErrorKind::NoSuchBucket(_)
+        ))
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_empty_bucket() {
+        let client = localstack_test_client().await;
+
+        let stream = list_objects(&client, "empty-bucket", None);
+        let results = stream.try_collect::<Vec<_>>().await.unwrap();
+        assert_eq!(results, vec![]);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_no_prefix() {
+        let client = localstack_test_client().await;
+
+        let stream = list_objects(&client, "test-bucket", None);
+        let mut results = stream.try_collect::<Vec<_>>().await.unwrap();
+        results.sort_by_cached_key(|x| x.size);
+        assert_eq!(results.len(), 2503);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_with_prefix() {
+        let client = localstack_test_client().await;
+
+        let stream = list_objects(&client, "test-bucket", Some("some-prefix".into()));
+        let results = stream.try_collect::<Vec<_>>().await.unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(
+            results[0].key,
+            Some("some-prefix/nested-prefix/nested.txt".into())
+        );
+        assert_eq!(results[0].size, 12);
+        assert_eq!(results[1].key, Some("some-prefix/prefixed.txt".into()));
+        assert_eq!(results[1].size, 14);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_with_prefix_slash() {
+        let client = localstack_test_client().await;
+
+        let stream = list_objects(&client, "test-bucket", Some("some-prefix/".into()));
+        let results = stream.try_collect::<Vec<_>>().await.unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(
+            results[0].key,
+            Some("some-prefix/nested-prefix/nested.txt".into())
+        );
+        assert_eq!(results[0].size, 12);
+        assert_eq!(results[1].key, Some("some-prefix/prefixed.txt".into()));
+        assert_eq!(results[1].size, 14);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_with_nested_prefix() {
+        let client = localstack_test_client().await;
+
+        let stream = list_objects(
+            &client,
+            "test-bucket",
+            Some("some-prefix/nested-prefix".into()),
+        );
+        let results = stream.try_collect::<Vec<_>>().await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].key,
+            Some("some-prefix/nested-prefix/nested.txt".into())
+        );
+        assert_eq!(results[0].size, 12);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_with_partial_prefix() {
+        let client = localstack_test_client().await;
+
+        let stream = list_objects(&client, "test-bucket", Some("empty-pre".into()));
+        let results = stream.try_collect::<Vec<_>>().await.unwrap();
+        assert_eq!(results.len(), 0);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_with_empty_prefix() {
+        let client = localstack_test_client().await;
+
+        let stream = list_objects(&client, "test-bucket", Some("empty-prefix".into()));
+        let results = stream.try_collect::<Vec<_>>().await.unwrap();
+        assert_eq!(results.len(), 0);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_with_multiple_pages() {
+        let client = localstack_test_client().await;
+
+        let stream = list_objects(&client, "test-bucket", Some("multi-page".into()));
+        let results = stream.try_collect::<Vec<_>>().await.unwrap();
+        assert_eq!(results.len(), 2500);
     }
 }

--- a/test-data/some-prefix/nested-prefix/nested.txt
+++ b/test-data/some-prefix/nested-prefix/nested.txt
@@ -1,0 +1,1 @@
+nested data

--- a/test-data/some-prefix/prefixed.txt
+++ b/test-data/some-prefix/prefixed.txt
@@ -1,0 +1,1 @@
+prefixed data

--- a/test-data/test.txt
+++ b/test-data/test.txt
@@ -1,0 +1,1 @@
+test data


### PR DESCRIPTION
## What

This PR adds a function 

```
pub fn list_objects(
    client: &Client,
    bucket: impl Into<String>,
    prefix: Option<String>,
) -> impl Stream<Item = Result<model::Object, SdkError<ListObjectsV2Error>>> + Unpin {
```

which generates a `Stream` of objects at a location in s3. Internally the function uses the `list_objects_v2` with pagination.

## Why

When processing many small files in S3 it can be helpful treat the object listing as a stream to be processed. This can also be helpful when analysing the contents of a bucket without needing to actually open the files.

## Notes

This PR also adds support for running out unit tests in the context of a pre-prepared localstack instance. This allows us to do things like run listings against a pre-prepared s3 bucket and ensure that it behaves as expected.