### PR TITLE
Prepare release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.2.0
+
  - Added `athena::get_client()`, which creates an Athena client with LocalStack support.
  - Added `s3::get_object()`, which retrieves an object from S3 as an AsyncBufRead.
  - Added `s3::list_objects()`, which performs a bucket listing, returning a stream of results.
  - Added `s3::AsyncPutObject`, which implements the AsyncWrite trait and writes data to S3 using the put_object API.
  - Added `lambda::run_message_handler()`, which simplifies the task of writing a Lambda function which is triggered by an SQS event source mapping.
  - Moved test dependencies into `dev-dependencies`.
+ - Fixed broken link in docs.
+ - Updated `aws-sdk-*` dependencies to `0.7.0`.
+ - Updated `aws_lambda_events` dependency to `0.6.0`.
 
 ## 0.1.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cobalt-aws"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["harrison.ai Data Engineering <dataengineering@harrison.ai>"]
 edition = "2021"
 description = "This library provides a collection of wrappers around the aws-sdk-rust and lambda_runtime packages."

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,8 +3,8 @@
 To make a release of `cobalt-aws`, follow these steps:
 
 1. Prepare a release PR:
-   -  Update the version in Cargo.toml to the target version
-   -  Update the Changelog by changing the "Unreleased" heading to the target version and creating a blank Unrelease section
+   -  Update the version in `Cargo.toml` to the target version
+   -  Update `CHANGELOG.md` by changing the "Unreleased" heading to the target version and creating a blank Unreleased section
    -  Review the PR history since the previous release and ensure the changelog contents are up to date and correct.
 3. Push PR and merge into `main`
    - Trigger publish from Github actions (TODO), or


### PR DESCRIPTION
## What

Bumps the version and updates the changelog for the 0.2.0 release.

## Why

We're ready for release 🚀

This is step 1 of https://github.com/harrison-ai/cobalt-aws/blob/main/RELEASE.md
