### PR TITLE
fix: Avoid busy-waiting the waker in `AsyncPutObject`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+ - Reduced spurious task wake-ups when closing an `s3::AsyncPutObject`.
+
 ## 0.2.0
 
  - Added `athena::get_client()`, which creates an Athena client with LocalStack support.


### PR DESCRIPTION
## What

Remove the explicit calls to `cx.waker().wake_by_ref()`, instead delegating wakes to the underlying future.

## Why

I was curious to see if I could remove the calls to `cx.waker().wake_by_ref()`, which IIUC will essentially cause us to busy-wait the executor by immediately waking up whenever we're put to sleep. This seems to work, as long as we're careful to always poll the underlying future before returning `Poll::Pending`.

@timleslie could you please try this out and see if it behaves correctly for you, or if you're able to reproduce any of the deadlocking behaviour you saw previously?

## Depends on

N/A

