### PR TITLE
Add sqs::get_client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+ - Added `sqs::get_client()`, which creates an SQS client with LocalStack support.
  - Reduced spurious task wake-ups when closing an `s3::AsyncPutObject`.
+ - Updated `aws-sdk-*` dependencies to `0.8.0`.
 
 ## 0.2.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ async-trait = "0.1.52"
 aws-config = "0.8.0"
 aws-sdk-athena = "0.8.0"
 aws-sdk-s3 = "0.8.0"
+aws-sdk-sqs = "0.8.0"
 aws_lambda_events = "0.6.1"
 clap = { version = "3.1.5", features = ["derive", "env"] }
 futures = "0.3.21"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 pub mod athena;
 pub mod lambda;
 pub mod s3;
+pub mod sqs;
 
 // Internal shared modules
 mod localstack;

--- a/src/sqs.rs
+++ b/src/sqs.rs
@@ -1,0 +1,71 @@
+//! A collection of wrappers around the [aws_sdk_sqs](https://docs.rs/aws-sdk-sqs/latest/aws_sdk_sqs/) crate.
+
+use anyhow::Result;
+use aws_sdk_sqs::{config, Endpoint};
+
+use crate::localstack;
+
+/// Re-export of [aws_sdk_sqs::client::Client](https://docs.rs/aws-sdk-sqs/latest/aws_sdk_sqs/client/struct.Client.html).
+///
+pub use aws_sdk_sqs::Client;
+
+/// Create an SQS client with LocalStack support.
+///
+/// # Example
+///
+/// ```
+/// use aws_config;
+/// use cobalt_aws::sqs:get_client;
+///
+/// # tokio_test::block_on(async {
+/// let shared_config = aws_config::load_from_env().await;
+/// let client = get_client(&shared_config).unwrap();
+/// # })
+/// ```
+///
+/// ## LocalStack
+///
+/// This client supports running on [LocalStack](https://localstack.cloud/).
+///
+/// If you're using this client from within a Lambda function that is running on
+/// LocalStack, it will automatically setup the correct endpoint.
+///
+/// If you're using this client from outside of LocalStack but want to communicate
+/// with a LocalStack instance, then set the environment variable `LOCALSTACK_HOSTNAME`:
+///
+/// ```shell
+/// $ export LOCALSTACK_HOSTNAME=localhost
+/// ```
+///
+/// You can also optionally set the `EDGE_PORT` variable if you need something other
+/// than the default of `4566`.
+///
+/// See the [LocalStack configuration docs](https://docs.localstack.cloud/localstack/configuration/) for more info.
+///
+/// ## Errors
+///
+/// An error will be returned if `LOCALSTACK_HOSTNAME` is set and a valid URI cannot be constructed.
+///
+pub fn get_client(shared_config: &aws_config::Config) -> Result<Client> {
+    let mut builder = config::Builder::from(shared_config);
+    if let Some(uri) = localstack::get_endpoint_uri()? {
+        builder = builder.endpoint_resolver(Endpoint::immutable(uri));
+    }
+    Ok(Client::from_conf(builder.build()))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use aws_config;
+    use serial_test::serial;
+    use tokio;
+
+    #[tokio::test]
+    #[serial]
+    async fn test_get_client() {
+        let config = aws_config::load_from_env().await;
+        get_client(&config).unwrap();
+    }
+}

--- a/src/sqs.rs
+++ b/src/sqs.rs
@@ -15,7 +15,7 @@ pub use aws_sdk_sqs::Client;
 ///
 /// ```
 /// use aws_config;
-/// use cobalt_aws::sqs:get_client;
+/// use cobalt_aws::sqs::get_client;
 ///
 /// # tokio_test::block_on(async {
 /// let shared_config = aws_config::load_from_env().await;


### PR DESCRIPTION
## What

Adds an `sqs::get_client()` function to create an SQS client with LocalStack support.

## Why

This lets us setup multiple lambdas which communicate via SQS queues in a LocalStack environment.
