### PR TITLE
Add sqs::send_messages_concurrently()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+ - Added `sqs::send_messages_concurrently`, which sends a stream of messages to an SQS queue.
  - Added `sqs::get_client()`, which creates an SQS client with LocalStack support.
  - Reduced spurious task wake-ups when closing an `s3::AsyncPutObject`.
  - Updated `aws-sdk-*` dependencies to `0.8.0`.

--- a/scripts/init-localstack.sh
+++ b/scripts/init-localstack.sh
@@ -21,4 +21,6 @@ set -x
 awslocal s3 mb s3://test-bucket
 awslocal s3 cp /tmp/test-data s3://test-bucket --recursive
 
+awslocal sqs create-queue --queue-name test-queue
+
 printf "Configuration done"

--- a/src/s3/mod.rs
+++ b/src/s3/mod.rs
@@ -82,7 +82,7 @@ pub fn get_client(shared_config: &aws_config::Config) -> Result<Client> {
 /// # })
 /// ```
 ///
-///  # Implementation details
+/// # Implementation details
 ///
 /// This function uses the [ListObjectsV2](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html)
 /// API and performs pagination to ensure all objects are returned.

--- a/src/sqs.rs
+++ b/src/sqs.rs
@@ -1,7 +1,9 @@
 //! A collection of wrappers around the [aws_sdk_sqs](https://docs.rs/aws-sdk-sqs/latest/aws_sdk_sqs/) crate.
 
 use anyhow::Result;
+use aws_sdk_sqs::model::SendMessageBatchRequestEntry;
 use aws_sdk_sqs::{config, Endpoint};
+use futures::{Stream, StreamExt, TryFutureExt, TryStreamExt};
 
 use crate::localstack;
 
@@ -54,6 +56,82 @@ pub fn get_client(shared_config: &aws_config::Config) -> Result<Client> {
     Ok(Client::from_conf(builder.build()))
 }
 
+const BATCH_SIZE: usize = 10;
+
+/// Send message to a queue from a stream with concurrent invocations of `SendMessageBatch`.
+///
+/// This function retrieves items from the stream until it has exhausted. Any errors
+/// in the stream, or while processing the stream, are returned as soon as they are encountered.
+///
+/// If `concurrency` is `None` then message batches are sent sequentially. A `concurrency` value of
+/// zero, `Some(0)`, is not allowed.
+///
+/// # Example
+///
+/// ```no_run
+/// use aws_config;
+/// use futures::stream;
+/// use cobalt_aws::sqs::{get_client, send_messages_concurrently};
+///
+/// # tokio_test::block_on(async {
+/// let shared_config = aws_config::load_from_env().await;
+/// let client = get_client(&shared_config).unwrap();
+///
+/// let messages = stream::iter(vec![Ok("Hello"), Ok("world")]);
+/// let queue_name = "MyQueue";
+///
+/// // Send up to 4 concurrent API requests at once.
+/// send_messages_concurrently(&client, queue_name, Some(4), messages).await.unwrap();
+/// # })
+/// ```
+///
+/// # Implementation details
+/// This function uses the [SendMessageBatch](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessageBatch.html)
+/// API to send message in batches of 10, which is the maximum allowed batch size.
+pub async fn send_messages_concurrently<Msg: serde::Serialize, St: Stream<Item = Result<Msg>>>(
+    client: &Client,
+    queue_name: &str,
+    concurrency: Option<usize>,
+    msg_stream: St,
+) -> Result<()> {
+    if concurrency == Some(0) {
+        anyhow::bail!("Zero concurrency not allowed.");
+    }
+    let queue_url = client
+        .get_queue_url()
+        .queue_name(queue_name)
+        .send()
+        .await?
+        .queue_url
+        .ok_or(anyhow::anyhow!("Missing queue name"))?;
+    msg_stream
+        .map(|msg| Ok::<_, anyhow::Error>(serde_json::to_string(&msg?)?))
+        .enumerate()
+        .map(|(i, s)| {
+            Ok::<_, anyhow::Error>(
+                SendMessageBatchRequestEntry::builder()
+                    .message_body(s?)
+                    .id(format!("{}", i))
+                    .build(),
+            )
+        })
+        .try_chunks(BATCH_SIZE)
+        .map_err(anyhow::Error::from)
+        .inspect_ok(|entries| tracing::debug!("Sending message batch: {:#?}", entries))
+        .map_ok(|entries| {
+            client
+                .send_message_batch()
+                .queue_url(&queue_url)
+                .set_entries(Some(entries))
+                .send()
+                .map_err(anyhow::Error::from)
+                .map_ok(|_| ())
+        })
+        .try_buffered(concurrency.unwrap_or(1))
+        .try_collect::<()>()
+        .await
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -67,5 +145,172 @@ mod test {
     async fn test_get_client() {
         let config = aws_config::load_from_env().await;
         get_client(&config).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod test_list_objects {
+    use super::*;
+    use aws_config;
+    use aws_sdk_sqs::error::GetQueueUrlError;
+    use futures::stream;
+    use serial_test::serial;
+    use tokio;
+
+    async fn localstack_test_client() -> Client {
+        localstack::test_utils::wait_for_localstack().await;
+        let shared_config = aws_config::load_from_env().await;
+        get_client(&shared_config).unwrap()
+    }
+
+    async fn consume_queue(client: &Client, queue_name: &str) -> Vec<usize> {
+        let queue_url = client
+            .get_queue_url()
+            .queue_name(queue_name)
+            .send()
+            .await
+            .unwrap()
+            .queue_url
+            .unwrap();
+
+        // FIXME: use batch operations
+        let mut results: Vec<usize> = vec![];
+        while let Ok(x) = client
+            .receive_message()
+            .wait_time_seconds(1)
+            .queue_url(&queue_url)
+            .send()
+            .await
+        {
+            match x.messages {
+                Some(ref messages) => {
+                    assert_eq!(messages.len(), 1);
+                    let message = &messages[0];
+                    results.push(message.body.as_ref().unwrap().parse().unwrap());
+                    client
+                        .delete_message()
+                        .queue_url(&queue_url)
+                        .receipt_handle(message.receipt_handle.as_ref().unwrap())
+                        .send()
+                        .await
+                        .unwrap();
+                }
+                None => break,
+            }
+        }
+        results.sort_unstable();
+        results
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_non_existent_queue() {
+        let client = localstack_test_client().await;
+
+        let item_stream = stream::iter(vec![Ok::<u32, _>(1), Ok(2), Ok(3)]);
+
+        let queue_name = "non-existent-queue";
+
+        let result = send_messages_concurrently(&client, queue_name, None, item_stream).await;
+        let e = result.unwrap_err();
+        let e = e
+            .source()
+            .unwrap()
+            .downcast_ref::<GetQueueUrlError>()
+            .unwrap();
+
+        assert!(matches!(
+            e.kind,
+            aws_sdk_sqs::error::GetQueueUrlErrorKind::QueueDoesNotExist(_)
+        ));
+        assert_eq!(e.code(), Some("AWS.SimpleQueueService.NonExistentQueue"));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_item_stream_error() {
+        let client = localstack_test_client().await;
+
+        let item_stream = stream::iter(vec![
+            Ok::<u32, _>(1),
+            Ok(2),
+            Err(anyhow::anyhow!("some error")),
+            Ok(3),
+        ]);
+
+        let queue_name = "test-queue";
+
+        let result = send_messages_concurrently(&client, queue_name, None, item_stream).await;
+        let e = result.unwrap_err();
+        assert_eq!(e.to_string(), "some error");
+
+        let values = consume_queue(&client, queue_name).await;
+        assert!(values.is_empty());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_less_than_batch_size() {
+        let client = localstack_test_client().await;
+
+        let item_stream = stream::iter((0..5).map(Ok));
+
+        let queue_name = "test-queue";
+
+        let result = send_messages_concurrently(&client, queue_name, None, item_stream).await;
+        result.unwrap();
+
+        let values = consume_queue(&client, queue_name).await;
+        assert_eq!(values, (0..5).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_more_than_batch_size() {
+        let client = localstack_test_client().await;
+
+        let item_stream = stream::iter((0..25).map(Ok));
+
+        let queue_name = "test-queue";
+
+        let result = send_messages_concurrently(&client, queue_name, None, item_stream).await;
+        result.unwrap();
+
+        let values = consume_queue(&client, queue_name).await;
+        assert_eq!(values, (0..25).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_concurrent() {
+        let client = localstack_test_client().await;
+
+        let item_stream = stream::iter((0..250).map(Ok));
+
+        let queue_name = "test-queue";
+
+        let result = send_messages_concurrently(&client, queue_name, Some(5), item_stream).await;
+        result.unwrap();
+
+        let values = consume_queue(&client, queue_name).await;
+        assert_eq!(values, (0..250).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_zero_concurrency() {
+        let client = localstack_test_client().await;
+
+        let item_stream = stream::iter((0..250).map(Ok));
+
+        let queue_name = "test-queue";
+
+        let result = send_messages_concurrently(&client, queue_name, Some(0), item_stream).await;
+        let e = result.unwrap_err();
+
+        assert_eq!(e.to_string(), "Zero concurrency not allowed.");
+
+        let values = consume_queue(&client, queue_name).await;
+        assert!(values.is_empty());
     }
 }

--- a/src/sqs.rs
+++ b/src/sqs.rs
@@ -104,7 +104,7 @@ pub async fn send_messages_concurrently<Msg: serde::Serialize, St: Stream<Item =
         .send()
         .await?
         .queue_url
-        .ok_or_else(|| anyhow::anyhow!("Failed to get queue URL for {queue_name}"))?;
+        .ok_or_else(|| anyhow::anyhow!("Failed to get queue URL for {}", queue_name))?;
     msg_stream
         .map(|msg| Ok::<_, anyhow::Error>(serde_json::to_string(&msg?)?))
         .enumerate()
@@ -286,7 +286,7 @@ mod test_send_messages_concurrently {
     async fn test_concurrent() {
         let client = localstack_test_client().await;
 
-        let item_stream = stream::iter((0..250).map(Ok));
+        let item_stream = stream::iter((0..105).map(Ok));
 
         let queue_name = "test-queue";
 
@@ -294,7 +294,7 @@ mod test_send_messages_concurrently {
         result.unwrap();
 
         let values = consume_queue(&client, queue_name).await;
-        assert_eq!(values, (0..250).collect::<Vec<_>>());
+        assert_eq!(values, (0..105).collect::<Vec<_>>());
     }
 
     #[tokio::test]
@@ -302,7 +302,7 @@ mod test_send_messages_concurrently {
     async fn test_zero_concurrency() {
         let client = localstack_test_client().await;
 
-        let item_stream = stream::iter((0..250).map(Ok));
+        let item_stream = stream::iter((0..105).map(Ok));
 
         let queue_name = "test-queue";
 


### PR DESCRIPTION
## What

This PR adds a function to push a stream of messages to an SQS queue with concurrent calls to `send_message_batch()`.

## Why

This function allows a stream of messages to be pushed to SQS quickly and efficiently.