### PR TITLE
Update docs to include `RECORD_CONCURRENCY`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+ - Added support for processing messages concurrently by setting the `RECORD_CONCURRENCY` env var.
  - Updated `aws-sdk-*` dependencies to `0.9.0`.
 
 ## 0.3.0


### PR DESCRIPTION
## What

Adds public documentation for the `RECORD_CONCURRENCY` env var, and updates the CHANGELOG with a reference to this new feature.

## Why

We want all our features to be fully documented, and to have a comprehensive changelog.

## Notes

I also made a slight cosmetic change to the code to hopefully make it more readable.