### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.4.0
+
  - Added support for processing messages concurrently by setting the `RECORD_CONCURRENCY` env var.
  - Updated `aws-sdk-*` dependencies to `0.9.0`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cobalt-aws"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["harrison.ai Data Engineering <dataengineering@harrison.ai>"]
 edition = "2021"
 description = "This library provides a collection of wrappers around the aws-sdk-rust and lambda_runtime packages."


### PR DESCRIPTION
## What

Bumps the version number and updates the changelog file in preparation for a release.

## Why

We would like to make the concurrent lambda execution available for use.
