### PR TITLE
Add config::load_from_env()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+ - Added `config::load_from_env()`, which creates an `SdkConfig` with LocalStack support.
  - Updated `aws-sdk-*` dependencies to `0.13.0`.
 
 ## 0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ aws-config = "0.13.0"
 aws-sdk-athena = "0.13.0"
 aws-sdk-s3 = "0.13.0"
 aws-sdk-sqs = "0.13.0"
+aws-smithy-http = "0.43.0"
 aws-types = "0.13.0"
 aws_lambda_events = "0.6.3"
 clap = { version = "3.2.5", features = ["derive", "env"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-//! A collection of wrappers around the [aws_sdk_sqs](https://docs.rs/aws-sdk-sqs/latest/aws_sdk_sqs/) crate.
+//! A collection of wrappers around the [aws_types::SdkConfig](https://docs.rs/aws-types/0.13.0/aws_types/sdk_config/struct.SdkConfig.html) object.
 
 use anyhow::Result;
 use aws_smithy_http::endpoint::Endpoint;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,67 @@
+//! A collection of wrappers around the [aws_sdk_sqs](https://docs.rs/aws-sdk-sqs/latest/aws_sdk_sqs/) crate.
+
+use anyhow::Result;
+use aws_smithy_http::endpoint::Endpoint;
+use aws_types::SdkConfig;
+
+use crate::localstack;
+
+/// Create a shared `SdkConfig` with LocalStack support.
+///
+/// # Example
+///
+/// ```
+/// use aws_config;
+/// use cobalt_aws::config::load_from_env;
+/// use cobalt_aws::s3::Client;
+///
+/// # tokio_test::block_on(async {
+/// let shared_config = load_from_env().await.unwrap();
+/// let client = Client::new(&shared_config);
+/// # })
+/// ```
+///
+/// ## LocalStack
+///
+/// This shared `SdkConfig` supports creating clients that run on [LocalStack](https://localstack.cloud/).
+///
+/// If you use this config to create a client from within a Lambda function that is running on
+/// LocalStack, it will automatically setup the correct endpoint.
+///
+/// If you use this config to create a client from outside of LocalStack but want to communicate
+/// with a LocalStack instance, then set the environment variable `LOCALSTACK_HOSTNAME`:
+///
+/// ```shell
+/// $ export LOCALSTACK_HOSTNAME=localhost
+/// ```
+///
+/// You can also optionally set the `EDGE_PORT` variable if you need something other
+/// than the default of `4566`.
+///
+/// See the [LocalStack configuration docs](https://docs.localstack.cloud/localstack/configuration/) for more info.
+///
+/// ## Errors
+///
+/// An error will be returned if `LOCALSTACK_HOSTNAME` is set and a valid URI cannot be constructed.
+///
+pub async fn load_from_env() -> Result<SdkConfig> {
+    let mut shared_config = aws_config::from_env();
+    if let Some(uri) = localstack::get_endpoint_uri()? {
+        shared_config = shared_config.endpoint_resolver(Endpoint::immutable(uri));
+    }
+    Ok(shared_config.load().await)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use serial_test::serial;
+    use tokio;
+
+    #[tokio::test]
+    #[serial]
+    async fn test_load_from_client() {
+        load_from_env().await.unwrap();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 // Public modules
 
 pub mod athena;
+pub mod config;
 pub mod lambda;
 pub mod s3;
 pub mod sqs;


### PR DESCRIPTION
## What

This PR adds a function `config::load_from_env()`,  which creates an `SdkConfig` with LocalStack support.

## Why

Since `aws-sdk-*` `0.10.0`, the `SdkConfig` object supports setting the `endpoint_resolver()`. See https://github.com/awslabs/smithy-rs/pull/1300

This means users no longer need to set this endpoint on every client object they create. Instead, they can set it once on the shared `SdkConfig` object. In particular, this means we no longer need to support a `get_client()` function for every service. In a subsequent PR we will deprecate these functions, and then remove them in a subsequent reelase.

## Concerns

We still need to improve our testing of this functionality and LocalStack testing in general. For now, I've run a local experiment against a lambda which uses `aws_cobalt` and verified that it ran correctly against this PR.