### PR TITLE
Deprecate the get_client() family of functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
  - Added `config::load_from_env()`, which creates an `SdkConfig` with LocalStack support.
+ - Deprecated `s3::get_client()`, `sqs::get_client()`, and `athena::get_client()`.
  - Updated `aws-sdk-*` dependencies to `0.13.0`.
 
 ## 0.4.0

--- a/src/athena.rs
+++ b/src/athena.rs
@@ -74,6 +74,7 @@ mod test {
     #[serial]
     async fn test_get_client() {
         let config = aws_config::load_from_env().await;
+        #[allow(deprecated)]
         get_client(&config).unwrap();
     }
 }

--- a/src/athena.rs
+++ b/src/athena.rs
@@ -47,6 +47,13 @@ pub use aws_sdk_athena::Client;
 ///
 /// An error will be returned if `LOCALSTACK_HOSTNAME` is set and a valid URI cannot be constructed.
 ///
+#[deprecated(
+    since = "0.5.0",
+    note = r#"
+To create a `Client` with LocalStack support use `aws_cobalt::config::load_from_env()` to create a `SdkConfig` with LocalStack support.
+Then `aws_sdk_athena::Client::new(&shared_config)` to create the `Client`.
+"#
+)]
 pub fn get_client(shared_config: &SdkConfig) -> Result<Client> {
     let mut builder = config::Builder::from(shared_config);
     if let Some(uri) = localstack::get_endpoint_uri()? {

--- a/src/s3/async_put_object.rs
+++ b/src/s3/async_put_object.rs
@@ -27,12 +27,13 @@ enum PutObjectState<'a> {
 ///
 /// ```no_run
 /// use aws_config;
-/// use cobalt_aws::s3::{get_client, AsyncPutObject};
+/// use cobalt_aws::s3::{AsyncPutObject, Client};
+/// use cobalt_aws::config::load_from_env;
 /// use futures::AsyncWriteExt;
 ///
 /// # tokio_test::block_on(async {
-/// let shared_config = aws_config::load_from_env().await;
-/// let client = get_client(&shared_config).unwrap();
+/// let shared_config = load_from_env().await.unwrap();
+/// let client = Client::new(&shared_config);
 ///
 /// let mut writer = AsyncPutObject::new(&client, "my-bucket", "my-key");
 /// writer.write_all(b"File contents").await.unwrap();

--- a/src/s3/async_put_object.rs
+++ b/src/s3/async_put_object.rs
@@ -131,6 +131,7 @@ impl<'a> AsyncWrite for AsyncPutObject<'a> {
 mod test_async_put_object {
     use super::*;
     use crate::localstack;
+    #[allow(deprecated)]
     use crate::s3::get_client;
     use aws_config;
     use futures::{AsyncReadExt, AsyncWriteExt};
@@ -141,6 +142,7 @@ mod test_async_put_object {
     async fn localstack_test_client() -> Client {
         localstack::test_utils::wait_for_localstack().await;
         let shared_config = aws_config::load_from_env().await;
+        #[allow(deprecated)]
         get_client(&shared_config).unwrap()
     }
 

--- a/src/s3/mod.rs
+++ b/src/s3/mod.rs
@@ -159,6 +159,7 @@ mod test {
     #[serial]
     async fn test_get_client() {
         let shared_config = aws_config::load_from_env().await;
+        #[allow(deprecated)]
         get_client(&shared_config).unwrap();
     }
 }
@@ -175,6 +176,7 @@ mod test_list_objects {
     async fn localstack_test_client() -> Client {
         localstack::test_utils::wait_for_localstack().await;
         let shared_config = aws_config::load_from_env().await;
+        #[allow(deprecated)]
         get_client(&shared_config).unwrap()
     }
 
@@ -311,6 +313,7 @@ mod test_get_object {
     async fn localstack_test_client() -> Client {
         localstack::test_utils::wait_for_localstack().await;
         let shared_config = aws_config::load_from_env().await;
+        #[allow(deprecated)]
         get_client(&shared_config).unwrap()
     }
 

--- a/src/s3/mod.rs
+++ b/src/s3/mod.rs
@@ -56,6 +56,13 @@ pub use async_put_object::AsyncPutObject;
 ///
 /// An error will be returned if `LOCALSTACK_HOSTNAME` is set and a valid URI cannot be constructed.
 ///
+#[deprecated(
+    since = "0.5.0",
+    note = r#"
+To create a `Client` with LocalStack support use `aws_cobalt::config::load_from_env()` to create a `SdkConfig` with LocalStack support.
+Then `aws_sdk_s3::Client::new(&shared_config)` to create the `Client`.
+"#
+)]
 pub fn get_client(shared_config: &SdkConfig) -> Result<Client> {
     let mut builder = config::Builder::from(shared_config);
     if let Some(uri) = localstack::get_endpoint_uri()? {

--- a/src/s3/mod.rs
+++ b/src/s3/mod.rs
@@ -77,12 +77,13 @@ pub fn get_client(shared_config: &SdkConfig) -> Result<Client> {
 ///
 /// ```no_run
 /// use aws_config;
-/// use cobalt_aws::s3::{get_client, list_objects};
+/// use cobalt_aws::s3::{Client, list_objects};
+/// use cobalt_aws::config::load_from_env;
 /// use futures::TryStreamExt;
 ///
 /// # tokio_test::block_on(async {
-/// let shared_config = aws_config::load_from_env().await;
-/// let client = get_client(&shared_config).unwrap();
+/// let shared_config = load_from_env().await.unwrap();
+/// let client = Client::new(&shared_config);
 /// let mut objects = list_objects(&client, "my-bucket", Some("prefix".into()));
 /// while let Some(item) = objects.try_next().await.unwrap() {
 ///     println!("{:?}", item);

--- a/src/sqs.rs
+++ b/src/sqs.rs
@@ -79,11 +79,12 @@ const BATCH_SIZE: usize = 10;
 /// ```no_run
 /// use aws_config;
 /// use futures::stream;
-/// use cobalt_aws::sqs::{get_client, send_messages_concurrently};
+/// use cobalt_aws::sqs::{Client, send_messages_concurrently};
+/// use cobalt_aws::config::load_from_env;
 ///
 /// # tokio_test::block_on(async {
-/// let shared_config = aws_config::load_from_env().await;
-/// let client = get_client(&shared_config).unwrap();
+/// let shared_config = load_from_env().await.unwrap();
+/// let client = Client::new(&shared_config);
 ///
 /// let messages = stream::iter(vec![Ok("Hello"), Ok("world")]);
 /// let queue_name = "MyQueue";

--- a/src/sqs.rs
+++ b/src/sqs.rs
@@ -49,6 +49,13 @@ pub use aws_sdk_sqs::Client;
 ///
 /// An error will be returned if `LOCALSTACK_HOSTNAME` is set and a valid URI cannot be constructed.
 ///
+#[deprecated(
+    since = "0.5.0",
+    note = r#"
+To create a `Client` with LocalStack support use `aws_cobalt::config::load_from_env()` to create a `SdkConfig` with LocalStack support.
+Then `aws_sdk_sqs::Client::new(&shared_config)` to create the `Client`.
+"#
+)]
 pub fn get_client(shared_config: &SdkConfig) -> Result<Client> {
     let mut builder = config::Builder::from(shared_config);
     if let Some(uri) = localstack::get_endpoint_uri()? {

--- a/src/sqs.rs
+++ b/src/sqs.rs
@@ -153,6 +153,7 @@ mod test {
     #[serial]
     async fn test_get_client() {
         let config = aws_config::load_from_env().await;
+        #[allow(deprecated)]
         get_client(&config).unwrap();
     }
 }
@@ -169,6 +170,7 @@ mod test_send_messages_concurrently {
     async fn localstack_test_client() -> Client {
         localstack::test_utils::wait_for_localstack().await;
         let shared_config = aws_config::load_from_env().await;
+        #[allow(deprecated)]
         get_client(&shared_config).unwrap()
     }
 


### PR DESCRIPTION
## What

This PR deprecates the `get_client()` functions in favour of the new `config::load_from_env()` function, which provides LocalStack support for all clients without the need for per-service hlper functions.

## Why

Now that `load_from_env()` exists, these functions no longer need to exist. Deprecating rather than deleting will allow users of the library a smoother transition path.

