### PR TITLE
chore: Update tracing-subscriber for yanked packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ serde = "1.0.137"
 serde_json = "1.0.81"
 tokio = { version = "1.19.2", features=["macros"] }
 tracing = "0.1.35"
-tracing-subscriber = { version = "0.3.12", features=["json", "env-filter"] }
+tracing-subscriber = { version = "0.3.11", features=["json", "env-filter"] }
 
 [dev-dependencies]
 reqwest = { version = "0.11.11", features=["json"] }


### PR DESCRIPTION
## What

Rolls back the version of `tracing-subscriber`.

## Why

The version we depend on has been yanked.

https://crates.io/crates/tracing-subscriber/versions
