### PR TITLE
fix: Avoid failure if a handler argument is provided to the lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+ - Fixed incorrect environment variable parsing when running Image-based lambdas in LocalStack.
  - Updated `aws-sdk-*` dependencies to `0.15.0`.
 
 ## 0.5.0

--- a/scripts/read_logs.sh
+++ b/scripts/read_logs.sh
@@ -20,4 +20,4 @@ if [ -z "$STREAM_NAME" ] || [ "$STREAM_NAME" = "null" ]; then
     exit 1
 fi
 
-$AWSLOCAL logs get-log-events --log-group-name /aws/lambda/$EXAMPLE --log-stream-name "$STREAM_NAME" --start-from-head | jq
+$AWSLOCAL logs get-log-events --log-group-name /aws/lambda/$EXAMPLE --log-stream-name "$STREAM_NAME" --start-from-head | jq -r '.events[].message'

--- a/scripts/run_example.sh
+++ b/scripts/run_example.sh
@@ -37,7 +37,7 @@ $AWSLOCAL lambda create-function \
    --role=rn:aws:iam:local \
    --zip-file=fileb://lambda.zip \
    --environment "Variables={$ENV}" \
-   --handler "explicit handler"
+   --runtime=provided
 
 # Create an event source mapping
 $AWSLOCAL lambda create-event-source-mapping --function-name $EXAMPLE --event-source-arn "$QUEUE_ARN"

--- a/scripts/run_example.sh
+++ b/scripts/run_example.sh
@@ -36,8 +36,7 @@ $AWSLOCAL lambda create-function \
    --function-name=$EXAMPLE \
    --role=rn:aws:iam:local \
    --zip-file=fileb://lambda.zip \
-   --environment "Variables={$ENV}" \
-   --runtime=provided
+   --environment "Variables={$ENV}"
 
 # Create an event source mapping
 $AWSLOCAL lambda create-event-source-mapping --function-name $EXAMPLE --event-source-arn "$QUEUE_ARN"

--- a/scripts/run_example.sh
+++ b/scripts/run_example.sh
@@ -36,7 +36,8 @@ $AWSLOCAL lambda create-function \
    --function-name=$EXAMPLE \
    --role=rn:aws:iam:local \
    --zip-file=fileb://lambda.zip \
-   --environment "Variables={$ENV}"
+   --environment "Variables={$ENV}" \
+   --handler "explicit handler"
 
 # Create an event source mapping
 $AWSLOCAL lambda create-event-source-mapping --function-name $EXAMPLE --event-source-arn "$QUEUE_ARN"

--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -10,7 +10,9 @@ use clap::Parser;
 use futures::stream::{self, StreamExt, TryStreamExt};
 use futures::FutureExt;
 use lambda_runtime::{service_fn, LambdaEvent};
+use std::ffi::OsString;
 use std::future::Future;
+use std::iter::empty;
 use std::sync::Arc;
 use tracing_subscriber::filter::EnvFilter;
 
@@ -188,7 +190,7 @@ where
             )
             .json()
             .init();
-        let env = Env::try_parse().context(
+        let env = Env::try_parse_from(empty::<OsString>()).context(
             "An error occurred while parsing environment variables for message context.",
         )?;
         let ctx = Arc::new(Context::from_env(&env).await?);
@@ -198,7 +200,7 @@ where
     })()
     .await;
 
-    let handler_env: HandlerEnv = HandlerEnv::try_parse()
+    let handler_env: HandlerEnv = HandlerEnv::try_parse_from(empty::<OsString>())
         .context("An error occured while parsing environment variable for handler")?;
 
     lambda_runtime::run(service_fn(|event: LambdaEvent<SqsEvent>| async {

--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -190,6 +190,12 @@ where
             )
             .json()
             .init();
+        // We only care about values provided as environment variables, so we pass in an empty
+        // iterator, rather than having clap parse the command line arguments. This avoids an
+        // unfortunate issue in LocalStack where a command line arg of "handler.handler" is provided
+        // as a command line argument to the process when using an Image based lambda. This triggers
+        // a problem, as clap (wrongly, IMHO) tries to assign this command line option to the first
+        //element of the Env struct, and then ignores any actual environment variable provided.
         let env = Env::try_parse_from(empty::<OsString>()).context(
             "An error occurred while parsing environment variables for message context.",
         )?;


### PR DESCRIPTION
## What

This PR adds a workaround for some unexpected behaviour in the combination of LocalStack and `clap` which can cause environment variable parsing to fail when running Image based lambdas in LocalStack.

## Why

When running Image based lambdas in LocalStack, I observed that a command line argument of `handler.handler` was being provided to the rust binary process. I need to further investigate how/why this is being passed in. I believe it to be a bug, but I haven't confirmed that.

This command line value was in turn parsed by `clap` as part of our environment parsing. The behaviour of `clap` was to assign this command line value to the first element of the `Env` struct, and then ignore any environment variable provided for that element. This caused the wrong value to be provided to the `Env` struct (although it was considered valid, as my use case expected a `String` value for this first element). The code would then attempt to parse the `HandlerEnv`, at which point it would fail, as `HandlerEnv.record_concurrency` is a `usize` value, which cannot be parsed from a string.

This PR works around this situation by always passing an empty iterator to `Env::try_parse_from()`, since we never care about any command line arguments anyway.

