### PR TITLE
Prepare 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.6.0
+
  - Fixed incorrect environment variable parsing when running Image-based lambdas in LocalStack.
  - Updated `aws-sdk-*` dependencies to `0.15.0`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cobalt-aws"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["harrison.ai Data Engineering <dataengineering@harrison.ai>"]
 edition = "2021"
 description = "This library provides a collection of wrappers around the aws-sdk-rust and lambda_runtime packages."


### PR DESCRIPTION
## What

Bumped version number and updated changelog.

## Why

It's shipping time!
