### PR TITLE
DO NOT MERGE; experiment with local build of rust tooling image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,10 @@ test: dc-build
 	$(DCRUN) cargo test
 
 ## test-examples:	test example code using localstack
-# FIXME: turn this into an actual test with assertions
-# Currently you need to visually inspect that the correct log output is generated.
 test-examples:
 	./scripts/run_example.sh
-	sleep 20
-	./scripts/read_logs.sh
+	sleep 10
+	./scripts/read_and_validate_logs.sh
 
 ## fmt:          format all code using standard conventions
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DCRUN = docker-compose run --rm --user $(UID)
 .DEFAULT_GOAL := help
 
 ## test:         run all the tests
-test:
+test: dc-build
 	$(DCRUN) cargo test
 
 ## test-examples:	test example code using localstack

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ version: '3.7'
 services:
 
   cargo:
-    image: harrisonai/rust:1.60-0.2
+    #image: harrisonai/rust:1.60-0.2
+    build:
+      context: scripts/dataeng-tooling-rust
     entrypoint: cargo
     volumes:
       - '~/.cargo/registry:/usr/local/cargo/registry'

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,5 +12,5 @@ To run these examples local, you will need to have [LocalStack installed](EXAMPL
 To read the output logs of the lambda, run the script:
 
 ```shell
-./scripts/read_logs.sh
+./scripts/read_and_validate_logs.sh
 ```

--- a/scripts/dataeng-tooling-rust/CHANGELOG.md
+++ b/scripts/dataeng-tooling-rust/CHANGELOG.md
@@ -1,0 +1,84 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+but version numbers for this repo and a little complicated because they track
+both the Rust version and our own changes no top; consule [`./README.md`] for details.
+
+Every commit to `main` in this project creates a new release and hence must have
+a new version number. Fill in an appropriate changelog entry in this file to
+get CI passing and enable the changes to land on `main`.
+
+## 1.60-0.2
+
+- Bump GitHub Actions docker digest
+
+## 1.60-0.1
+
+- Updated Rust version to `1.60.0`
+- Updated `cargo-deny` to `0.11.4`
+- Updated `cargo-about` to `0.5.1`
+- Updated `cargo-release` to `0.20.5`
+- Updated `zlib` to `1.2.12`
+- Updated GitHub Actions docker images
+
+## 1.58-0.1
+
+- Updated Rust version to `1.58.1`.
+
+## 1.57-0.3
+
+- Added `curl` and `jq` to the image, since we've been frequently finding
+  ourselves needing these for customization.
+
+## 1.57-0.2
+
+- Added `cargo-release` to the image, for easily cutting releases.
+
+## 1.57-0.1
+
+- Updated Rust version to `1.57.0`.
+
+## 1.56-0.5
+
+- Sped up build time of the docker image by sharing build artifacts
+  between runs of `cargo install`.
+
+## 1.56-0.4
+
+- Added `cargo-about` for generating a license file describing the
+  open-source dependencies used in a project.
+- Updated `cargo-deny` to v0.11.0. This is a semver-breaking change
+  for `cargy-deny` because it updated its minimum supported Rust version
+  to 1.561, but we're already on that version of Rust anyway so it's
+  not semver-breaking for this docker image.
+
+## 1.56-0.3
+
+- Added x86_64-unknown-linux-musl cargo target support.
+- Add static compliation of openssl and zlib.
+
+## 1.56-0.2
+
+### Changed
+
+- The bundled `cargo-deny` now links against the system OpenSSL rather than
+  its own bundled copy.
+
+### Removed
+
+- The base image now derives from the "slim" debian variant, meaning that
+  a lot of system tools have been removed. For example, `curl` is no longer
+  present by default in the image.
+
+## 1.56-0.1
+
+### Added
+
+- The first release of this docker image, including Rust version `1.56.1` and
+  some basic scripting around `cargo-deny`.
+
+## 1.56-0.0
+
+This is a stub version for the initial commit, not corresponding to an
+actual release of the image.

--- a/scripts/dataeng-tooling-rust/Dockerfile
+++ b/scripts/dataeng-tooling-rust/Dockerfile
@@ -1,0 +1,109 @@
+#
+# Configures a Rust and Cargo dev environment with the specific
+# tools needed for working on harrison.ai Rust projects.
+#
+FROM rust:1.60-slim
+
+# Install extra system dependencies not included in the slim base image.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    # For helping to build some Rust crates.
+    libssl-dev \
+    pkg-config \
+    # For their general extreme usefulness.
+    jq \
+    curl \
+    # For cross-compilation to AWS Graviton2.
+#    gcc-aarch64-linux-gnu \
+#    libc-dev-arm64-cross \
+#    musl-tools \
+    make \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# General dev tools.
+RUN rustup component add rustfmt
+RUN rustup component add clippy
+
+# Install some helpful extra Rust utilities.
+# We build these in a single `RUN` invocation with a shared target-dir
+# so that cargo can share intermediate compile artifacts rather than
+# having to build everything from scratch, which saves a lot of compile
+# time in release mode.
+RUN export CARGO_TARGET_DIR=/tmp/cargo-install-target \
+  # cargo-deny: used for dependency license and security checks.
+  # Disabling default features lets it use the system ssl library,
+  # which should reduce overall size of the docker image.
+  && cargo install --version="0.11.4" --no-default-features cargo-deny \
+  # cargo-about: used for generating license files for distribution to consumers,
+  #              which may be required for compliance with some open-source licenses.
+  && cargo install --version="0.5.1" cargo-about \
+  # cargo-release: used for cutting releases.
+  && cargo install --version="0.20.5" cargo-release \
+  # Remove temporary files from the final image.
+  && rm -rf "$CARGO_HOME/registry" /tmp/cargo-install-target
+
+# Configure cross-compilation support for AWS Graviton2 processors,
+# and x86_64 linux static binary.
+# We use musl to help produce smaller docker images.
+#RUN rustup target add aarch64-unknown-linux-musl x86_64-unknown-linux-musl
+#ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc
+
+# Extra stuff required for cross-compiling the `ring` crate.
+#ENV CC_aarch64_unknown_linux_musl=aarch64-linux-gnu-gcc
+#ENV AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar
+
+# Extra stuff required for x86_64 musl
+# openssl crate supports OpenSSL 1.0.1 to 1.1.1 (not 3.0.0)
+#ENV SSL_VER="1.1.1l" \
+#    ZLIB_VER="1.2.12" \
+#    CC=musl-gcc \
+#    PREFIX=/musl \
+#    PATH=/usr/local/bin:/root/.cargo/bin:$PATH \
+#    PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
+#    LD_LIBRARY_PATH=$PREFIX
+
+# Set up a prefix for musl build libraries, make the linker's job of finding them easier
+# Primarily for the benefit of postgres.
+# Lastly, link some linux-headers for openssl 1.1 (not used herein)
+#RUN mkdir $PREFIX && \
+#    echo "$PREFIX/lib" >> /etc/ld-musl-x86_64.path && \
+#    ln -s /usr/include/x86_64-linux-gnu/asm /usr/include/x86_64-linux-musl/asm && \
+#    ln -s /usr/include/asm-generic /usr/include/x86_64-linux-musl/asm-generic && \
+#    ln -s /usr/include/linux /usr/include/x86_64-linux-musl/linux
+
+# Build zlib used in openssl
+#RUN curl -sSL https://zlib.net/zlib-$ZLIB_VER.tar.gz > zlib-${ZLIB_VER}.tar.gz && \
+#    echo "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9" \
+#    zlib-${ZLIB_VER}.tar.gz | sha256sum --check && \
+#    tar -xzf zlib-${ZLIB_VER}.tar.gz && \
+#    rm zlib-${ZLIB_VER}.tar.gz && \
+#    cd zlib-$ZLIB_VER && \
+#    CC="musl-gcc -fPIC -pie" LDFLAGS="-L$PREFIX/lib" CFLAGS="-I$PREFIX/include" ./configure --static --prefix=$PREFIX && \
+#    make -j$(nproc) && make install && \
+#    cd .. && rm -rf zlib-$ZLIB_VER
+
+# Build openssl 
+#RUN curl -sSL https://www.openssl.org/source/openssl-${SSL_VER}.tar.gz > openssl-${SSL_VER}.tar.gz && \
+#    echo "0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1" \
+#    openssl-${SSL_VER}.tar.gz | sha256sum --check && \
+#    tar -xzf openssl-${SSL_VER}.tar.gz && \
+#    rm openssl-${SSL_VER}.tar.gz && \
+#    cd openssl-$SSL_VER && \
+#    ./Configure no-shared -fPIC --prefix=$PREFIX --openssldir=$PREFIX/ssl linux-x86_64 && \
+#    env C_INCLUDE_PATH=$PREFIX/include make depend 2> /dev/null && \
+#    make -j$(nproc) && make install_sw && \
+#    cd .. && rm -rf openssl-$SSL_VER
+
+#ENV PATH=$PREFIX/bin:$PATH \
+#    PKG_CONFIG_ALLOW_CROSS=true \
+#    PKG_CONFIG_ALL_STATIC=true \
+#    PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig \
+#    OPENSSL_STATIC=true \
+#    OPENSSL_DIR=$PREFIX \
+#    SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+#    SSL_CERT_DIR=/etc/ssl/certs \
+#    LIBZ_SYS_STATIC=1
+
+# An easy way to run our standard suite of CI checks.
+COPY ./scripts/cargo-hai-all-checks /usr/local/cargo/bin

--- a/scripts/dataeng-tooling-rust/Dockerfile
+++ b/scripts/dataeng-tooling-rust/Dockerfile
@@ -14,9 +14,9 @@ RUN apt-get update \
     jq \
     curl \
     # For cross-compilation to AWS Graviton2.
-#    gcc-aarch64-linux-gnu \
-#    libc-dev-arm64-cross \
-#    musl-tools \
+#     gcc-aarch64-linux-gnu \
+    libc-dev-arm64-cross \
+    musl-tools \
     make \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
@@ -46,64 +46,53 @@ RUN export CARGO_TARGET_DIR=/tmp/cargo-install-target \
 # Configure cross-compilation support for AWS Graviton2 processors,
 # and x86_64 linux static binary.
 # We use musl to help produce smaller docker images.
-#RUN rustup target add aarch64-unknown-linux-musl x86_64-unknown-linux-musl
-#ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc
-
-# Extra stuff required for cross-compiling the `ring` crate.
-#ENV CC_aarch64_unknown_linux_musl=aarch64-linux-gnu-gcc
-#ENV AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar
+RUN rustup target add aarch64-unknown-linux-musl x86_64-unknown-linux-musl
 
 # Extra stuff required for x86_64 musl
 # openssl crate supports OpenSSL 1.0.1 to 1.1.1 (not 3.0.0)
-#ENV SSL_VER="1.1.1l" \
-#    ZLIB_VER="1.2.12" \
-#    CC=musl-gcc \
-#    PREFIX=/musl \
-#    PATH=/usr/local/bin:/root/.cargo/bin:$PATH \
-#    PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
-#    LD_LIBRARY_PATH=$PREFIX
-
-# Set up a prefix for musl build libraries, make the linker's job of finding them easier
-# Primarily for the benefit of postgres.
-# Lastly, link some linux-headers for openssl 1.1 (not used herein)
-#RUN mkdir $PREFIX && \
-#    echo "$PREFIX/lib" >> /etc/ld-musl-x86_64.path && \
-#    ln -s /usr/include/x86_64-linux-gnu/asm /usr/include/x86_64-linux-musl/asm && \
-#    ln -s /usr/include/asm-generic /usr/include/x86_64-linux-musl/asm-generic && \
-#    ln -s /usr/include/linux /usr/include/x86_64-linux-musl/linux
+ENV SSL_VER="1.1.1l" \
+   ZLIB_VER="1.2.12" \
+   CC="musl-gcc -static -idirafter /usr/include/ -idirafter /usr/include/aarch64-linux-gnu/"\
+   PREFIX=/musl \
+   PATH=/usr/local/bin:/root/.cargo/bin:$PATH \
+   PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
+   LD_LIBRARY_PATH=$PREFIX
 
 # Build zlib used in openssl
-#RUN curl -sSL https://zlib.net/zlib-$ZLIB_VER.tar.gz > zlib-${ZLIB_VER}.tar.gz && \
-#    echo "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9" \
-#    zlib-${ZLIB_VER}.tar.gz | sha256sum --check && \
-#    tar -xzf zlib-${ZLIB_VER}.tar.gz && \
-#    rm zlib-${ZLIB_VER}.tar.gz && \
-#    cd zlib-$ZLIB_VER && \
-#    CC="musl-gcc -fPIC -pie" LDFLAGS="-L$PREFIX/lib" CFLAGS="-I$PREFIX/include" ./configure --static --prefix=$PREFIX && \
-#    make -j$(nproc) && make install && \
-#    cd .. && rm -rf zlib-$ZLIB_VER
+RUN curl -sSL https://zlib.net/zlib-$ZLIB_VER.tar.gz > zlib-${ZLIB_VER}.tar.gz && \
+   echo "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9" \
+   zlib-${ZLIB_VER}.tar.gz | sha256sum --check && \
+   tar -xzf zlib-${ZLIB_VER}.tar.gz && \
+   rm zlib-${ZLIB_VER}.tar.gz && \
+   cd zlib-$ZLIB_VER && \
+   CC="musl-gcc -fPIC -pie" LDFLAGS="-L$PREFIX/lib" CFLAGS="-I$PREFIX/include" ./configure --static --prefix=$PREFIX && \
+   make -j$(nproc) && make install && \
+   cd .. && rm -rf zlib-$ZLIB_VER
 
-# Build openssl 
-#RUN curl -sSL https://www.openssl.org/source/openssl-${SSL_VER}.tar.gz > openssl-${SSL_VER}.tar.gz && \
-#    echo "0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1" \
-#    openssl-${SSL_VER}.tar.gz | sha256sum --check && \
-#    tar -xzf openssl-${SSL_VER}.tar.gz && \
-#    rm openssl-${SSL_VER}.tar.gz && \
-#    cd openssl-$SSL_VER && \
-#    ./Configure no-shared -fPIC --prefix=$PREFIX --openssldir=$PREFIX/ssl linux-x86_64 && \
-#    env C_INCLUDE_PATH=$PREFIX/include make depend 2> /dev/null && \
-#    make -j$(nproc) && make install_sw && \
-#    cd .. && rm -rf openssl-$SSL_VER
+# Build openssl
+RUN curl -sSL https://www.openssl.org/source/openssl-${SSL_VER}.tar.gz > openssl-${SSL_VER}.tar.gz && \
+   echo "0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1" \
+   openssl-${SSL_VER}.tar.gz | sha256sum --check && \
+   tar -xzf openssl-${SSL_VER}.tar.gz && \
+   rm openssl-${SSL_VER}.tar.gz && \
+   cd openssl-$SSL_VER && \
+   ./Configure no-shared -DOPENSSL_NO_SECURE_MEMORY -fPIC --prefix=$PREFIX --openssldir=$PREFIX/ssl linux-aarch64 && \
+   env C_INCLUDE_PATH=$PREFIX/include make depend 2> /dev/null && \
+   make -j$(nproc) && make install_sw && \
+   cd .. && rm -rf openssl-$SSL_VER
 
-#ENV PATH=$PREFIX/bin:$PATH \
-#    PKG_CONFIG_ALLOW_CROSS=true \
-#    PKG_CONFIG_ALL_STATIC=true \
-#    PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig \
-#    OPENSSL_STATIC=true \
-#    OPENSSL_DIR=$PREFIX \
-#    SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
-#    SSL_CERT_DIR=/etc/ssl/certs \
-#    LIBZ_SYS_STATIC=1
+# # for the cc crate
+# ENV HOST_CC=gcc
+
+ENV PATH=$PREFIX/bin:$PATH \
+   PKG_CONFIG_ALLOW_CROSS=true \
+   PKG_CONFIG_ALL_STATIC=true \
+   PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig \
+   OPENSSL_STATIC=true \
+   OPENSSL_DIR=$PREFIX \
+   SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+   SSL_CERT_DIR=/etc/ssl/certs \
+   LIBZ_SYS_STATIC=1
 
 # An easy way to run our standard suite of CI checks.
 COPY ./scripts/cargo-hai-all-checks /usr/local/cargo/bin

--- a/scripts/dataeng-tooling-rust/Makefile
+++ b/scripts/dataeng-tooling-rust/Makefile
@@ -1,0 +1,10 @@
+
+.DEFAULT_GOAL := help
+
+## publish:			build docker images and push to registry
+publish:
+	./scripts/publish.sh
+
+## help:			show this help
+help:
+	@sed -ne '/@sed/!s/## //p' $(MAKEFILE_LIST)

--- a/scripts/dataeng-tooling-rust/README.md
+++ b/scripts/dataeng-tooling-rust/README.md
@@ -1,0 +1,99 @@
+# Rust build and development tooling for harrison.ai
+
+This repository builds the [`harrisonai/rust`](https://hub.docker.com/r/harrisonai/rust)
+docker image, a convenient collection of Rust build and development tooling
+for working with Rust-based projects in the harrison.ai Data Engineering team.
+
+The docker image provides:
+
+* Rust, rustup, cargo and friends, like you'd get from a standard Rust dev image.
+* Pre-configured components and settings to cross-compile for `aarch64` targets,
+  for deployment to AWS
+* Pre-configured components and settings to cross-compile static binaries for x86\_64-unknown-linux targets,
+  with zlib and openssl statically compiled.
+* Useful project-lifecycle-management tools such as `cargo deny` for auditing
+  dependency licenses, `cargo about` for generating a license summary, and
+  `cargo release` for cutting releases.
+* A custom `cargo hai-all-checks` command to easily run our standard suite of
+  quality checks from a CI environment.
+
+## Using the image
+
+A typical workflow would be to mount your working directory in the image
+and then run various `cargo` build commands, like this:
+
+```sh
+docker run
+    # Automatically delete the container when it's finished running
+    --rm
+    # Mount your current working directory into the container
+    --volume `pwd`:/app
+    # Run commands in your current working directory
+    --workdir /app
+    # Use the published rust tooling image
+    harrisonai/rust
+    # To run various cargo build commands
+    cargo build
+```
+
+In repositories using the [three-musketeers pattern](https://3musketeers.io/)
+you can conveniently automate the environment setup in your `docker-compose.yml`
+like this:
+
+```
+services:
+  cargo:
+    image: harrisonai/rust:{version-tag}
+    entrypoint: cargo
+    volumes:
+      - '~/.cargo/registry:/usr/local/cargo/registry'
+      - '.:/app'
+    working_dir: '/app'
+```
+
+You can then invoke `cargo` via `docker-compose` like this:
+
+```
+docker-compose run --rm cargo build
+```
+
+We plan to publish a cookiecutter Rust project using this pattern, once we've
+stabilised some of the details.
+
+## Tags and Versioning
+
+In an attempt to minimise possible confusion for users, the docker image version
+reflects the underlying Rust version down to semver-minor level and appends a
+separate version number for the customizations that we layer on top. The general
+form is `harrisonai/rust:M.NN-X.Y` where:
+
+* `M.NN` is the semver-minor version of Rust included in the image.
+* `X.Y` is a major.minor version number for changes in this repo.
+
+So for example, `harrisonai/rust:1.56-1.3` would include the Rust toolchain at
+some version in the `1.56` series, and be the third release of our customizations
+on top of that series.
+
+Every commit merged to `main` in this repo creates a new version that is automatically
+built and pushed to dockerhub, with version number updated according to the following
+rules:
+
+* If the change were purely additive (e.g. installing some additional tools, or a new
+  point release of Rust) then it would move the version from `1.56-1.3` to `1.56-1.4`.
+* If the change had the potential for breakage (such as replacing `cargo-deny` with a
+  different tool) then it would move the version from `1.56-1.3` to `1.56-2.0`.
+* If the change updated to a new major or minor version of Rust, then it would move
+  the version from `1.56-1.3` to `1.57-1.0`.
+
+We also provide floating semver tags if you don't want to pin to a specific release:
+
+* `harrisonai/rust:M.NN-X` tracks the latest additive updates but should never pull
+  in any breaking changes.
+* `harrisonai/rust:M.NN` tracks all updates other than Rust version changes, and might
+  potentially receive breaking changes in the surrounding tooling.
+
+But please note that assessment of possible breaking changes is based purely on a
+best-effort human-in-the-loop basis.
+
+The scripting to manage all this is under [`./scripts`](./scripts) and is orchestrated
+by GitHub Actions.

--- a/scripts/dataeng-tooling-rust/renovate.json
+++ b/scripts/dataeng-tooling-rust/renovate.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "config:base"
+  ]
+}

--- a/scripts/dataeng-tooling-rust/scripts/cargo-hai-all-checks
+++ b/scripts/dataeng-tooling-rust/scripts/cargo-hai-all-checks
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# A standard suite of code-quality checks for harrison.ai Rust projects.
+#
+
+# Everything should be formatted according to `cargo fmt`.
+cargo fmt -- --check
+
+# Everything should be clippy clean, with no warnings.
+cargo clippy --all-targets --all-features --no-deps -- -D warnings
+
+# The dependency tree should be compatible with our various policies.
+cargo deny check

--- a/scripts/dataeng-tooling-rust/scripts/check-pr.sh
+++ b/scripts/dataeng-tooling-rust/scripts/check-pr.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Check that a PR is properly incrementing the version number.
+#
+# We use this as a check in GitHub Actions to ensure that every
+# commit landing on `main` has a corresponding changelog entry
+# and version number, allowing us to automatically build and publish
+# and image from it as soon as it lands.
+#
+
+set -e
+
+THIS_VERSION=`./scripts/version-number.sh`
+MAIN_VERSION=`./scripts/version-number.sh ${GITHUB_BASE_SHA-main}`
+
+if [ -z "${THIS_VERSION}" ]; then
+    echo "ERROR: no version number for the current checkout" 1>&2
+    exit 1
+fi
+
+if [ -z "${MAIN_VERSION}" ]; then
+    echo "ERROR: no version number for the main branch" 1>&2
+    exit 1
+fi
+
+if ./scripts/check-version-increment.py "${MAIN_VERSION}" "${THIS_VERSION}"; then true; else
+    echo ""
+    echo "Please update CHANGELOG.md with an appropriate new version number"
+    echo "and a description of what has changed, so that we can automatically"
+    echo "publish this change once it is merged."
+    echo ""
+    exit 1
+fi
+
+THIS_RUST_VERSION=`echo ${THIS_VERSION} | cut -s -d '-' -f 1`
+if grep "^FROM rust:${THIS_RUST_VERSION}" Dockerfile > /dev/null; then true; else
+    echo ""
+    echo "The first component of the version number in CHANGELOG.md does not match"
+    echo "the version of Rust used to build the Docker image. Please update the"
+    echo "version numbers to match before merging."
+    echo ""
+    exit 1
+fi
+
+echo "Looks good!"

--- a/scripts/dataeng-tooling-rust/scripts/check-version-increment.py
+++ b/scripts/dataeng-tooling-rust/scripts/check-version-increment.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+#
+# Check that a version number has correctly increased.
+# Called like:
+#
+#    ./scripts/check-version-increment.py OLD NEW
+#
+# This script will exit successfully if the new version number is bigger
+# than the old one.
+#
+# This one's in python rather than shell because it makes it much easier
+# to do looping numerical comparisons, and the GitHub Actions runner image
+# has python pre-installed.
+
+import sys
+
+
+def parse_version(version):
+    """Return the individual numeric parts of a version number."""
+    # Recall that the version format is "M.NN-X.Y".
+    parts = tuple(int(v) for vs in version.split("-") for v in vs.split("."))
+    if len(parts) != 4:
+        raise ValueError(f"Invalid version number: {version}")
+    return parts
+
+
+def check_version_increment(old_version, new_version):
+    """Check that new_version is strictly greater than old_version."""
+    # Recall that the version format is "M.NN-X.Y".
+    old_parts = parse_version(old_version)
+    new_parts = parse_version(new_version)
+    for (old, new) in zip(old_parts, new_parts):
+        if new > old:
+            return True
+        if new < old:
+            raise ValueError(f"Version {new_version} is less than {old_version}")
+    raise ValueError(f"The version number has not changed: {old_version}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        raise RuntimeError("Usage: ./scripts/check-version-increment.py OLD NEW")
+    check_version_increment(sys.argv[1], sys.argv[2])

--- a/scripts/dataeng-tooling-rust/scripts/publish.sh
+++ b/scripts/dataeng-tooling-rust/scripts/publish.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Publish the current git HEAD to dockerhub, if it's the main branch.
+#
+
+set -e
+
+IMAGE="harrisonai/rust"
+
+# We only ever publish from a clean checkout of `main`.
+if git diff --exit-code > /dev/null; then true; else 
+    echo "Refusing to publish from a working dir with unstaged changes"
+    exit 1
+fi
+if git diff --cached --exit-code > /dev/null; then true; else
+    echo "Refusing to publish from a working dir with uncommited changes"
+    exit 1
+fi
+if [ `git branch --show-current` != "main" ]; then
+    echo "Refusing to publish from a branch other than 'main'"
+    exit 1
+fi
+
+VERSION=`./scripts/version-number.sh`
+RUST_VERSION=`echo ${VERSION} | cut -s -d '-' -f 1`
+OUR_MAJOR_VERSION="$RUST_VERSION-`echo ${VERSION} | cut -s -d '-' -f 2 | cut -s -d '.' -f 1`"
+echo "Building image with tags: '${VERSION}', '${OUR_MAJOR_VERSION}', '${RUST_VERSION}', 'latest'"
+
+docker build -t "${IMAGE}:latest" \
+    -t "${IMAGE}:${VERSION}" \
+    -t "${IMAGE}:${OUR_MAJOR_VERSION}" \
+    -t "${IMAGE}:${RUST_VERSION}" \
+    .
+
+docker push "${IMAGE}:latest"
+docker push "${IMAGE}:${VERSION}"
+docker push "${IMAGE}:${OUR_MAJOR_VERSION}"
+docker push "${IMAGE}:${RUST_VERSION}"

--- a/scripts/dataeng-tooling-rust/scripts/version-number.sh
+++ b/scripts/dataeng-tooling-rust/scripts/version-number.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Get the latest version number in the changelog file in git.
+#
+# This is a little trick to help ensure we maintain a changelog and think
+# breaking changes up front, and also to help us easily publish new images
+# built from commits as soon as they merge to master.
+#
+
+set -e
+
+# By default this script will read the latest version number from the changelog
+# in the git `HEAD` ref, but you can pass a specific git ref as first argument.
+GITREF="${1-HEAD}"
+
+# In words:
+#  * read the changelog at the specified ref
+#  * find all markdown subheadings that contain just a version number
+#  * take the first one
+#  * delete all the non-version-number characters
+VERSION=`git show $GITREF:CHANGELOG.md | grep "^## [0-9]\+\.[0-9]\+-[0-9]\+\.[0-9]\+$" | head -n 1 | tr -d "# "`
+
+if [ -z $VERSION ]; then
+    echo "Error: Unable to find version number in changelog" 1>&2
+    exit 1
+fi
+
+echo $VERSION

--- a/scripts/read_and_validate_logs.sh
+++ b/scripts/read_and_validate_logs.sh
@@ -5,6 +5,7 @@ AWSLOCAL="$DCRUN awslocal"
 
 export EXAMPLE=hello_lambda
 export DEFAULT_REGION=ap-southeast-2
+export EXPECTED_MESSAGE="hello, world!"
 
 # Read the logs
 
@@ -20,4 +21,21 @@ if [ -z "$STREAM_NAME" ] || [ "$STREAM_NAME" = "null" ]; then
     exit 1
 fi
 
-$AWSLOCAL logs get-log-events --log-group-name /aws/lambda/$EXAMPLE --log-stream-name "$STREAM_NAME" --start-from-head | jq -r '.events[].message'
+export LOGS=$($AWSLOCAL logs get-log-events --log-group-name /aws/lambda/$EXAMPLE --log-stream-name "$STREAM_NAME" --start-from-head \
+ | jq -r '.events[].message')
+
+log=$(echo $LOGS | sed -e 's/.*LATEST\(.*\)END.*/\1/' |  sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
+if [ -z "$log" ] || [ "$log" = "null" ]; then
+  echo "Empty logs"
+  exit 1
+fi
+
+message=$(echo $message | jq -r ".fields.message")
+if [ "$message" = "$EXPECTED_MESSAGE" ]; then
+  echo "Test passed!"
+  exit 0
+else
+  echo "Test failed: EXPECTED=$EXPECTED_MESSAGE; ACTUAL=$message."
+  exit 1
+fi
+


### PR DESCRIPTION
This is an experiment to see if building a platform-native tooling image will help with performance issues on the Mac M1.

What I've done here is basically copy the build scripts from https://github.com/harrison-ai/dataeng-tooling-rust/ into a local subdirectory, and configured docker-compose to build the image locally rather than pulling from dockerhub. In theory, if you run this on an M1 mac, it should build an arm64 image rather than using the published amd64 image under emulation.

To start, I've also commented out a bunch of cross-compilation tooling which I suspect will need a bit of tweaking to build on a new system.

On my machine, the following sequence of commands work nicely and in a timely manner:

* Checkout this branch
* Run `make dc-build` to build the local docker image
* Run `make test` to use it to compile the code and run the tests

@TanyaSrinidhi, when you get a chance, could you please try out the above on your machine and see if it (a) works and (b) improves the speed any?
