### PR TITLE
chore: Update read_logs.sh to include validation for test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,10 @@ test:
 	$(DCRUN) cargo test
 
 ## test-examples:	test example code using localstack
+# Sleep for 20s in between to let CI complete execution
 test-examples:
 	./scripts/run_example.sh
-	sleep 10
+	sleep 20
 	./scripts/read_and_validate_logs.sh
 
 ## fmt:          format all code using standard conventions

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,10 @@ test:
 	$(DCRUN) cargo test
 
 ## test-examples:	test example code using localstack
-# FIXME: turn this into an actual test with assertions
-# Currently you need to visually inspect that the correct log output is generated.
 test-examples:
 	./scripts/run_example.sh
-	sleep 20
-	./scripts/read_logs.sh
+	sleep 10
+	./scripts/read_and_validate_logs.sh
 
 ## fmt:          format all code using standard conventions
 fmt:

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,5 +12,5 @@ To run these examples local, you will need to have [LocalStack installed](EXAMPL
 To read the output logs of the lambda, run the script:
 
 ```shell
-./scripts/read_logs.sh
+./scripts/read_and_validate_logs.sh
 ```

--- a/scripts/read_and_validate_logs.sh
+++ b/scripts/read_and_validate_logs.sh
@@ -21,7 +21,10 @@ if [ -z "$STREAM_NAME" ] || [ "$STREAM_NAME" = "null" ]; then
     exit 1
 fi
 
-export AWS_LOGS=$($AWSLOCAL logs get-log-events --log-group-name /aws/lambda/$EXAMPLE --log-stream-name "$STREAM_NAME" --start-from-head | jq -r '.events[].message')
+# Debug
+$AWSLOCAL logs get-log-events --log-group-name /aws/lambda/$EXAMPLE --log-stream-name "$STREAM_NAME" --start-from-head | jq -r '.events[].message'
+
+AWS_LOGS="$($AWSLOCAL logs get-log-events --log-group-name /aws/lambda/$EXAMPLE --log-stream-name "$STREAM_NAME" --start-from-head | jq -r '.events[].message')"
 
 # Extracting the message and removing ASCII color tags
 log=$(echo $AWS_LOGS | sed -e 's/.*LATEST\(.*\)END.*/\1/' |  sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')

--- a/scripts/read_and_validate_logs.sh
+++ b/scripts/read_and_validate_logs.sh
@@ -21,9 +21,6 @@ if [ -z "$STREAM_NAME" ] || [ "$STREAM_NAME" = "null" ]; then
     exit 1
 fi
 
-# Debug
-$AWSLOCAL logs get-log-events --log-group-name /aws/lambda/$EXAMPLE --log-stream-name "$STREAM_NAME" --start-from-head | jq -r '.events[].message'
-
 AWS_LOGS="$($AWSLOCAL logs get-log-events --log-group-name /aws/lambda/$EXAMPLE --log-stream-name "$STREAM_NAME" --start-from-head | jq -r '.events[].message')"
 
 # Extracting the message and removing ASCII color tags

--- a/scripts/read_and_validate_logs.sh
+++ b/scripts/read_and_validate_logs.sh
@@ -5,6 +5,7 @@ AWSLOCAL="$DCRUN awslocal"
 
 export EXAMPLE=hello_lambda
 export DEFAULT_REGION=ap-southeast-2
+export EXPECTED_MESSAGE="hello, world!"
 
 # Read the logs
 
@@ -20,4 +21,20 @@ if [ -z "$STREAM_NAME" ] || [ "$STREAM_NAME" = "null" ]; then
     exit 1
 fi
 
-$AWSLOCAL logs get-log-events --log-group-name /aws/lambda/$EXAMPLE --log-stream-name "$STREAM_NAME" --start-from-head | jq -r '.events[].message'
+export LOGS=$($AWSLOCAL logs get-log-events --log-group-name /aws/lambda/$EXAMPLE --log-stream-name "$STREAM_NAME" --start-from-head \
+ | jq -r '.events[].message')
+
+log=$(echo $LOGS | sed -e 's/.*LATEST\(.*\)END.*/\1/' |  sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
+if [ -z "$log" ] || [ "$log" = "null" ]; then
+  echo "Empty logs"
+  exit 1
+fi
+
+message=$(echo $message | jq -r ".fields.message")
+if [ "$message" = "$EXPECTED_MESSAGE" ]; then
+  echo "Test passed!"
+  exit 0
+else
+  echo "Test failed: EXPECTED=$EXPECTED_MESSAGE; ACTUAL=$message."
+  exit 1
+fi

--- a/scripts/read_and_validate_logs.sh
+++ b/scripts/read_and_validate_logs.sh
@@ -21,16 +21,17 @@ if [ -z "$STREAM_NAME" ] || [ "$STREAM_NAME" = "null" ]; then
     exit 1
 fi
 
-export LOGS=$($AWSLOCAL logs get-log-events --log-group-name /aws/lambda/$EXAMPLE --log-stream-name "$STREAM_NAME" --start-from-head \
- | jq -r '.events[].message')
+export AWS_LOGS=`$AWSLOCAL logs get-log-events --log-group-name /aws/lambda/$EXAMPLE --log-stream-name "$STREAM_NAME" --start-from-head \
+ | jq -r '.events[].message'`
 
-log=$(echo $LOGS | sed -e 's/.*LATEST\(.*\)END.*/\1/' |  sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
+# Extracting the message and removing ASCII color tags
+log=$(echo $AWS_LOGS | sed -e 's/.*LATEST\(.*\)END.*/\1/' |  sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
 if [ -z "$log" ] || [ "$log" = "null" ]; then
   echo "Empty logs"
   exit 1
 fi
 
-message=$(echo $message | jq -r ".fields.message")
+message=$(echo $log | jq -r ".fields.message")
 if [ "$message" = "$EXPECTED_MESSAGE" ]; then
   echo "Test passed! Found expected message: $message"
   exit 0

--- a/scripts/read_and_validate_logs.sh
+++ b/scripts/read_and_validate_logs.sh
@@ -21,8 +21,7 @@ if [ -z "$STREAM_NAME" ] || [ "$STREAM_NAME" = "null" ]; then
     exit 1
 fi
 
-export AWS_LOGS=`$AWSLOCAL logs get-log-events --log-group-name /aws/lambda/$EXAMPLE --log-stream-name "$STREAM_NAME" --start-from-head \
- | jq -r '.events[].message'`
+export AWS_LOGS=$($AWSLOCAL logs get-log-events --log-group-name /aws/lambda/$EXAMPLE --log-stream-name "$STREAM_NAME" --start-from-head | jq -r '.events[].message')
 
 # Extracting the message and removing ASCII color tags
 log=$(echo $AWS_LOGS | sed -e 's/.*LATEST\(.*\)END.*/\1/' |  sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
@@ -30,7 +29,6 @@ if [ -z "$log" ] || [ "$log" = "null" ]; then
   echo "Empty logs"
   exit 1
 fi
-
 message=$(echo $log | jq -r ".fields.message")
 if [ "$message" = "$EXPECTED_MESSAGE" ]; then
   echo "Test passed! Found expected message: $message"

--- a/scripts/read_and_validate_logs.sh
+++ b/scripts/read_and_validate_logs.sh
@@ -32,7 +32,7 @@ fi
 
 message=$(echo $message | jq -r ".fields.message")
 if [ "$message" = "$EXPECTED_MESSAGE" ]; then
-  echo "Test passed!"
+  echo "Test passed! Found expected message: $message"
   exit 0
 else
   echo "Test failed: EXPECTED=$EXPECTED_MESSAGE; ACTUAL=$message."


### PR DESCRIPTION
## What

Update test-examples to include validation tests

## Why
Fixes #98 
To avoid visually inspecting that the correct log output is generated.

## Depends on


## Concerns

These changes have been tested on a aarch64 docker; Committing it here separately to let CI test without the M1 changes

## Notes


* See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info.
