### PR TITLE
[chore/tests] SQS consume multiple messages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
       - AWS_ACCESS_KEY_ID=placeholder
       - AWS_SECRET_ACCESS_KEY=placeholder
     depends_on:
-      - localstack
+      localstack:
+        condition: service_healthy
 
   awslocal:
     build:
@@ -53,3 +54,12 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock"
       - "./scripts/init-localstack.sh:/docker-entrypoint-initaws.d/init-localstack.sh"
       - "./test-data:/tmp/test-data"
+    healthcheck:
+      test:
+        - CMD
+        - bash
+        - -c
+        - awslocal s3 ls
+      interval: 2s
+      timeout: 10s
+      start_period: 5s

--- a/src/sqs.rs
+++ b/src/sqs.rs
@@ -191,23 +191,23 @@ mod test_send_messages_concurrently {
         let mut results: Vec<usize> = vec![];
         while let Ok(x) = client
             .receive_message()
-            .max_number_of_messages(i32::try_from(MAX_MESSAGES).ok().unwrap())
+            .max_number_of_messages(MAX_MESSAGES as i32)
             .wait_time_seconds(1)
             .queue_url(&queue_url)
             .send()
             .await
         {
             match x.messages {
-                Some(ref messages) => {
+                Some(messages) => {
                     assert!(messages.len() <= MAX_MESSAGES);
 
                     let results_delete = messages
-                        .iter()
+                        .into_iter()
                         .map(|msg| {
-                            results.push(msg.body.as_ref().unwrap().parse().unwrap());
+                            results.push(msg.body.unwrap().parse().unwrap());
                             DeleteMessageBatchRequestEntry::builder()
-                                .receipt_handle(msg.receipt_handle.as_ref().unwrap())
-                                .set_id(Some(msg.message_id.as_ref().unwrap().parse().unwrap()))
+                                .set_receipt_handle(msg.receipt_handle)
+                                .set_id(msg.message_id)
                                 .build()
                         })
                         .collect::<Vec<_>>();

--- a/src/sqs.rs
+++ b/src/sqs.rs
@@ -197,7 +197,6 @@ mod test_send_messages_concurrently {
             .send()
             .await
         {
-            // let mut results_delete: Vec<DeleteMessageBatchRequestEntry> = vec![];
             match x.messages {
                 Some(ref messages) => {
                     assert!(messages.len() <= MAX_MESSAGES);
@@ -207,8 +206,8 @@ mod test_send_messages_concurrently {
                         .map(|msg| {
                             results.push(msg.body.as_ref().unwrap().parse().unwrap());
                             DeleteMessageBatchRequestEntry::builder()
-                                .receipt_handle(msg.body.as_ref().unwrap())
-                                .set_id(Some(format!("{:?}", msg.message_id)))
+                                .receipt_handle(msg.receipt_handle.as_ref().unwrap())
+                                .set_id(Some(msg.message_id.as_ref().unwrap().parse().unwrap()))
                                 .build()
                         })
                         .collect::<Vec<_>>();
@@ -220,49 +219,10 @@ mod test_send_messages_concurrently {
                         .send()
                         .await
                         .unwrap();
-
-                    // for message in messages {
-                    //     results.push(message.body.as_ref().unwrap().parse().unwrap());
-                    //     results_delete.push(
-                    //         DeleteMessageBatchRequestEntry::builder()
-                    //             .receipt_handle(message.body.as_ref().unwrap())
-                    //             .set_id(Some(format!("{:?}", message.message_id)))
-                    //             .build(),
-                    //     )
-                    // }
-
-                    // client
-                    //     .delete_message_batch()
-                    //     .queue_url(&queue_url)
-                    //     .set_entries(Some(results_delete))
-                    //     .send()
-                    //     .await
-                    //     .unwrap();
                 }
                 None => break,
             }
         }
-
-        // results
-        //     .iter()
-        //     .map(|e| {
-        //         DeleteMessageBatchRequestEntry::builder()
-        //             .receipt_handle(e.to_string())
-        //             .set_id(Some(format!("{:?}", e)))
-        //             .build()
-        //     })
-        //     .collect::<Vec<_>>()
-        //     .chunks_mut(MAX_MESSAGES)
-        //     .collect::<Vec<_>>()
-        //     .into_iter()
-        //     .map(|entries| {
-        //         client
-        //             .delete_message_batch()
-        //             .queue_url(&queue_url)
-        //             .set_entries(Some(entries.to_vec()))
-        //             .send()
-        //     });
-
         results.sort_unstable();
         results
     }


### PR DESCRIPTION
## What

test: The SQS client has a max limit of 10 messages to retrieve and delete after it's done.
chore: docker-compose does not wait for the Localstack container to start to run

## Why

To perform batch operation on test consume queue (more #150 )

## Concerns


## Notes

