### PR TITLE
Prepare for 0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.8.0
+
  - Updated `aws-sdk-{athena,s3,sqs}` dependencies to `0.19.0`.
  - Updated `aws-{config, smithy-http, types}` dependencies to `0.49.0`.
  - Updated `aws_lambda_events` dependency to `0.7.0`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cobalt-aws"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["harrison.ai Data Engineering <dataengineering@harrison.ai>"]
 edition = "2021"
 description = "This library provides a collection of wrappers around the aws-sdk-rust and lambda_runtime packages."

--- a/licenses/licenses.html
+++ b/licenses/licenses.html
@@ -46,8 +46,8 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#MIT">MIT License</a> (32)</li>
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (26)</li>
+            <li><a href="#MIT">MIT License</a> (33)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (27)</li>
             <li><a href="#ISC">ISC License</a> (4)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (2)</li>
             <li><a href="#OpenSSL">OpenSSL License</a> (1)</li>
@@ -60,22 +60,23 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-config 0.46.0</a></li>
-                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-endpoint 0.46.0</a></li>
-                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-http 0.46.0</a></li>
-                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-sig-auth 0.46.0</a></li>
-                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-sigv4 0.46.0</a></li>
-                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-async 0.46.0</a></li>
-                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-client 0.46.0</a></li>
-                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-eventstream 0.46.0</a></li>
-                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-http 0.46.0</a></li>
-                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-http-tower 0.46.0</a></li>
-                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-json 0.46.0</a></li>
-                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-query 0.46.0</a></li>
-                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-types 0.46.0</a></li>
-                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-xml 0.46.0</a></li>
-                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-types 0.46.0</a></li>
-                    <li><a href=" https://github.com/harrison-ai/cobalt-aws/ ">cobalt-aws 0.7.0</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-config 0.49.0</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-endpoint 0.49.0</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-http 0.49.0</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-sig-auth 0.49.0</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-sigv4 0.49.0</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-async 0.49.0</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-checksums 0.49.0</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-client 0.49.0</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-eventstream 0.49.0</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-http 0.49.0</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-http-tower 0.49.0</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-json 0.49.0</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-query 0.49.0</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-types 0.49.0</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-xml 0.49.0</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-types 0.49.0</a></li>
+                    <li><a href=" https://github.com/harrison-ai/cobalt-aws/ ">cobalt-aws 0.8.0</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -258,6 +259,7 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide ">miniz_oxide 0.5.4</a></li>
                     <li><a href=" https://github.com/taiki-e/pin-project ">pin-project 1.0.10</a></li>
                     <li><a href=" https://github.com/taiki-e/pin-project ">pin-project-internal 1.0.10</a></li>
                     <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.9</a></li>
@@ -1286,9 +1288,9 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/clap-rs/clap ">clap 3.2.16</a></li>
-                    <li><a href=" https://github.com/clap-rs/clap/tree/master/clap_derive ">clap_derive 3.2.15</a></li>
-                    <li><a href=" https://github.com/clap-rs/clap/tree/master/clap_lex ">clap_lex 0.2.3</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap 4.0.4</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap/tree/master/clap_derive ">clap_derive 4.0.1</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap/tree/master/clap_lex ">clap_lex 0.3.0</a></li>
                     <li><a href=" https://github.com/dylni/os_str_bytes ">os_str_bytes 6.0.0</a></li>
                     <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.9</a></li>
                 </ul>
@@ -1923,11 +1925,11 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-athena 0.16.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-s3 0.16.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sqs 0.16.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sso 0.16.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sts 0.16.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-athena 0.19.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-s3 0.19.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sqs 0.19.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sso 0.19.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sts 0.19.0</a></li>
                 </ul>
                 <pre class="license-text">                                Apache License
                            Version 2.0, January 2004
@@ -2322,15 +2324,15 @@ END OF TERMS AND CONDITIONS
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures 0.3.21</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-channel 0.3.21</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-core 0.3.21</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-executor 0.3.21</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-io 0.3.21</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-macro 0.3.21</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-sink 0.3.21</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-task 0.3.21</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-util 0.3.21</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures 0.3.24</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-channel 0.3.24</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-core 0.3.24</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-executor 0.3.24</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-io 0.3.24</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-macro 0.3.24</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-sink 0.3.24</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-task 0.3.24</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-util 0.3.24</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -2748,7 +2750,7 @@ limitations under the License.</pre>
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/seanmonstar/reqwest ">reqwest 0.11.11</a></li>
+                    <li><a href=" https://github.com/seanmonstar/reqwest ">reqwest 0.11.12</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -3793,8 +3795,8 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.58</a></li>
-                    <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.56</a></li>
+                    <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.65</a></li>
+                    <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.57</a></li>
                     <li><a href=" https://github.com/cuviper/autocfg ">autocfg 1.1.0</a></li>
                     <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.13.0</a></li>
                     <li><a href=" https://github.com/bitflags/bitflags ">bitflags 1.3.2</a></li>
@@ -3804,9 +3806,11 @@ limitations under the License.
                     <li><a href=" https://github.com/ctz/ct-logs ">ct-logs 0.8.0</a></li>
                     <li><a href=" https://github.com/bluss/either ">either 1.6.1</a></li>
                     <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 1.7.0</a></li>
+                    <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2 1.0.24</a></li>
                     <li><a href=" https://github.com/servo/rust-fnv ">fnv 1.0.7</a></li>
                     <li><a href=" https://github.com/servo/rust-url ">form_urlencoded 1.0.1</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.11.2</a></li>
+                    <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.12.3</a></li>
                     <li><a href=" https://github.com/withoutboats/heck ">heck 0.4.0</a></li>
                     <li><a href=" https://github.com/seanmonstar/httparse ">httparse 1.6.0</a></li>
                     <li><a href=" https://github.com/ctz/hyper-rustls ">hyper-rustls 0.22.1</a></li>
@@ -3826,19 +3830,20 @@ limitations under the License.
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot_core 0.9.3</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding 2.1.0</a></li>
                     <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config 0.3.25</a></li>
-                    <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.40</a></li>
+                    <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.46</a></li>
                     <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.17</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex 1.5.5</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.6.25</a></li>
                     <li><a href=" https://github.com/Kimundi/rustc-version-rs ">rustc_version 0.4.0</a></li>
                     <li><a href=" https://github.com/ctz/rustls-native-certs ">rustls-native-certs 0.5.0</a></li>
-                    <li><a href=" https://github.com/dtolnay/rustversion ">rustversion 1.0.6</a></li>
                     <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.1.0</a></li>
                     <li><a href=" https://github.com/ctz/sct.rs ">sct 0.6.1</a></li>
                     <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.7</a></li>
-                    <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.140</a></li>
-                    <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.140</a></li>
-                    <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.82</a></li>
+                    <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.145</a></li>
+                    <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.145</a></li>
+                    <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.85</a></li>
+                    <li><a href=" https://github.com/jonasbb/serde_with ">serde_with 1.14.0</a></li>
+                    <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with_macros 1.5.2</a></li>
                     <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.8.0</a></li>
                     <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.4.4</a></li>
                     <li><a href=" https://github.com/dtolnay/syn ">syn 1.0.98</a></li>
@@ -4059,9 +4064,12 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.10.2</a></li>
+                    <li><a href=" https://github.com/RustCrypto/utils ">cpufeatures 0.2.5</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">crypto-common 0.1.6</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">digest 0.10.3</a></li>
                     <li><a href=" https://github.com/RustCrypto/hashes ">md-5 0.10.1</a></li>
+                    <li><a href=" https://github.com/RustCrypto/hashes ">sha1 0.10.4</a></li>
+                    <li><a href=" https://github.com/RustCrypto/hashes ">sha2 0.10.5</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -4258,6 +4266,215 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/jonas-schievink/adler.git ">adler 1.0.2</a></li>
+                </ul>
+                <pre class="license-text">                              Apache License
+                        Version 2.0, January 2004
+                     https://www.apache.org/licenses/LICENSE-2.0
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   &quot;control&quot; means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   &quot;Source&quot; form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   &quot;Object&quot; form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   &quot;Work&quot; shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   &quot;Contribution&quot; shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+   replaced with your own identifying information. (Don&#x27;t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same &quot;printed page&quot; as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
@@ -4898,8 +5115,10 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/chronotope/chrono ">chrono 0.4.19</a></li>
+                    <li><a href=" https://github.com/zowens/crc32c ">crc32c 0.6.3</a></li>
                     <li><a href=" https://gitlab.com/kornelski/http-serde ">http-serde 1.1.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-lambda-rust-runtime ">lambda_runtime 0.6.0</a></li>
+                    <li><a href=" https://github.com/TedDriggs/ident_case ">ident_case 1.0.1</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-lambda-rust-runtime ">lambda_runtime 0.6.1</a></li>
                     <li><a href=" https://github.com/awslabs/aws-lambda-rust-runtime ">lambda_runtime_api_client 0.6.0</a></li>
                     <li><a href=" https://github.com/ctz/rustls ">rustls 0.19.1</a></li>
                     <li><a href=" https://github.com/Soveu/tinyvec_macros ">tinyvec_macros 0.1.0</a></li>
@@ -5212,7 +5431,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/mio ">mio 0.8.2</a></li>
+                    <li><a href=" https://github.com/tokio-rs/mio ">mio 0.8.4</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014 Carl Lerche and other MIO contributors
 
@@ -5272,7 +5491,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/hyper ">hyper 0.14.18</a></li>
+                    <li><a href=" https://github.com/hyperium/hyper ">hyper 0.14.20</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014-2021 Sean McArthur
 
@@ -5450,8 +5669,8 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/palfrey/serial_test/ ">serial_test 0.8.0</a></li>
-                    <li><a href=" https://github.com/palfrey/serial_test/ ">serial_test_derive 0.8.0</a></li>
+                    <li><a href=" https://github.com/palfrey/serial_test/ ">serial_test 0.9.0</a></li>
+                    <li><a href=" https://github.com/palfrey/serial_test/ ">serial_test_derive 0.9.0</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2018 Tom Parker-Shemilt
 
@@ -5878,7 +6097,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.20.1</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.21.2</a></li>
                     <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.1</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2022 Tokio Contributors
@@ -5912,11 +6131,13 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/mgeisler/textwrap ">textwrap 0.15.0</a></li>
+                    <li><a href=" https://github.com/TedDriggs/darling ">darling 0.13.4</a></li>
+                    <li><a href=" https://github.com/TedDriggs/darling ">darling_core 0.13.4</a></li>
+                    <li><a href=" https://github.com/TedDriggs/darling ">darling_macro 0.13.4</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
-Copyright (c) 2016 Martin Geisler
+Copyright (c) 2017 Ted Driggs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -5941,7 +6162,36 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/LegNeato/aws-lambda-events ">aws_lambda_events 0.6.3</a></li>
+                    <li><a href=" https://github.com/xacrimon/dashmap ">dashmap 5.3.4</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2019 Acrimon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/LegNeato/aws-lambda-events ">aws_lambda_events 0.7.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 


### PR DESCRIPTION
## What

Prepares for the `0.8.0` release according to `RELEASE.md`.

## Why

We would like to publish an update with the latest `aws-*` dependencies and support for `clap` v4.
