### PR TITLE
feat/multipart-upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+ - Added AsyncMultipartUpload.
+ - Add S3Object.
+
 ## 0.8.0
 
  - Updated `aws-sdk-{athena,s3,sqs}` dependencies to `0.19.0`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ tracing-subscriber = { version = "0.3.16", features=["json", "env-filter"] }
 url = { version = "2.3.1", features = ["serde"] }
 
 [dev-dependencies]
+function_name = "0.3.0"
+rand = "0.8.5"
+rand_chacha = "0.3.1"
 reqwest = { version = "0.11.12", features=["json"] }
 serial_test = "0.9.0"
 tokio-test = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ aws-types = "0.49.0"
 aws_lambda_events = "0.7.0"
 bytesize = "1.1.0"
 clap = { version = "4.0.22", features = ["derive", "env"] }
+derivative = "2.2.0"
 futures = "0.3.25"
 http = "0.2.8"
 lambda_runtime = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ aws-sdk-sqs = "0.19.0"
 aws-smithy-http = "0.49.0"
 aws-types = "0.49.0"
 aws_lambda_events = "0.7.0"
+bytesize = "1.1.0"
 clap = { version = "4.0.22", features = ["derive", "env"] }
 futures = "0.3.25"
 http = "0.2.8"
@@ -35,6 +36,7 @@ serde_json = "1.0.87"
 tokio = { version = "1.21.2", features=["macros"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features=["json", "env-filter"] }
+url = { version = "2.3.1", features = ["serde"] }
 
 [dev-dependencies]
 reqwest = { version = "0.11.12", features=["json"] }

--- a/src/s3/async_multipart_put_object.rs
+++ b/src/s3/async_multipart_put_object.rs
@@ -127,7 +127,7 @@ impl<'a> AsyncMultipartUpload<'a> {
             anyhow::bail!("part_size was {part_size}, can not be more than {MAX_PART_SIZE}")
         }
 
-        //Check that used did not send in invalid parameter
+        //Check that user did not send in invalid parameter
         if let Some(0) = max_uploading_parts {
             anyhow::bail!("Max uploading parts must not be 0")
         }

--- a/src/s3/async_multipart_put_object.rs
+++ b/src/s3/async_multipart_put_object.rs
@@ -109,7 +109,7 @@ impl<'a> AsyncMultipartUpload<'a> {
     /// * `client`              - S3 client to use.
     /// * `dst`              - The [S3Object] to write the object into.
     /// * `part_size`           - How large, in bytes, each part should be.
-    /// * `max_uploading_parts` - How many parts to upload concurrently.
+    /// * `max_uploading_parts` - How many parts to upload concurrently (defaults to 100).
     #[instrument(skip(client))]
     pub async fn new(
         client: &'a Client,

--- a/src/s3/async_multipart_put_object.rs
+++ b/src/s3/async_multipart_put_object.rs
@@ -108,9 +108,9 @@ impl<'a> AsyncMultipartUpload<'a> {
     ///
     /// * `client`              - S3 client to use.
     /// * `dst`                 - The [S3Object] to write the object into.
-    /// * `part_size`           - How large, in bytes, each part should be. Must be 
+    /// * `part_size`           - How large, in bytes, each part should be. Must be
     /// larger than 5MIB and smaller that 5GIB.
-    /// * `max_uploading_parts` - How many parts to upload concurrently, 
+    /// * `max_uploading_parts` - How many parts to upload concurrently,
     /// Must be larger than 0 (defaults to 100).
     #[instrument(skip(client))]
     pub async fn new(

--- a/src/s3/async_multipart_put_object.rs
+++ b/src/s3/async_multipart_put_object.rs
@@ -1,0 +1,439 @@
+//! Provides ways of interacting with objects in S3.
+
+use anyhow::Context as _;
+use aws_sdk_s3::error::{CompleteMultipartUploadError, UploadPartError};
+use aws_sdk_s3::model::CompletedMultipartUpload;
+use aws_sdk_s3::model::CompletedPart;
+use aws_sdk_s3::model::ObjectCannedAcl;
+use aws_sdk_s3::output::{CompleteMultipartUploadOutput, UploadPartOutput};
+use aws_sdk_s3::types::{ByteStream, SdkError};
+use bytesize::{GIB, MIB};
+use futures::future::BoxFuture;
+use futures::io::{Error, ErrorKind};
+use futures::task::{Context, Poll};
+use futures::{ready, AsyncWrite, Future, FutureExt, TryFutureExt};
+use std::mem;
+use std::pin::Pin;
+
+use aws_sdk_s3::Client;
+use tracing::{event, instrument, Level};
+
+use crate::s3::S3Object;
+
+/// Convenience wrapper for boxed future
+type MultipartUploadFuture<'a> =
+    BoxFuture<'a, Result<(UploadPartOutput, i32), SdkError<UploadPartError>>>;
+/// Convenience wrapper for boxed future
+type CompleteMultipartUploadFuture<'a> =
+    BoxFuture<'a, Result<CompleteMultipartUploadOutput, SdkError<CompleteMultipartUploadError>>>;
+
+/// Holds state for the [AsyncMultipartUpload]
+enum AsyncMultipartUploadState<'a> {
+    ///Bytes are being written
+    Writing {
+        /// Multipart Uploads that are running
+        uploads: Vec<MultipartUploadFuture<'a>>,
+        /// Bytes waiting to be written.
+        buffer: Vec<u8>,
+        /// The next part number to be used.
+        part_number: i32,
+        /// The completed parts
+        completed_parts: Vec<CompletedPart>,
+    },
+    /// close() has been called and parts are still uploading.
+    CompletingParts {
+        uploads: Vec<MultipartUploadFuture<'a>>,
+        completed_parts: Vec<CompletedPart>,
+    },
+    /// All parts have been uploaded and the CompleteMultipart is returning.
+    Completing(CompleteMultipartUploadFuture<'a>),
+    // We have completed writing to S3.
+    Closed,
+}
+
+/// Configuration for the AsyncMultipartUpload which
+/// is separate from the state.
+/// This was to work around borrowing of two disjoint fields
+/// allowing this structure to be cloned.
+#[derive(Clone, Debug)]
+struct AsyncMultipartUploadConfig<'a> {
+    client: &'a Client,
+    dst: S3Object,
+    upload_id: String,
+    part_size: usize,
+    max_uploading_parts: usize,
+}
+
+/// A implementation of [AsyncWrite] for S3 objects using multipart uploads.
+/// By using multipart uploads constant memory usage can be achieved.
+///
+/// ## Note
+/// On failure the multipart upload is not aborted. It is up to the
+/// caller to call the S3 `abortMultipartUpload` API when required.
+pub struct AsyncMultipartUpload<'a> {
+    config: AsyncMultipartUploadConfig<'a>,
+    state: AsyncMultipartUploadState<'a>,
+}
+
+/// Minimum size of a multipart upload.
+const MIN_PART_SIZE: usize = 5_usize * MIB as usize; // 5 Mib
+/// Maximum size of a multipart upload.
+const MAX_PART_SIZE: usize = 5_usize * GIB as usize; // 5 Gib
+
+/// Default number of part which can be uploaded
+/// concurrently.
+const DEFAULT_MAX_UPLOADING_PARTS: usize = 100;
+
+impl<'a> AsyncMultipartUpload<'a> {
+    /// Create a new [AsyncMultipartUpload].
+    ///
+    /// * `client`              - S3 client to use.
+    /// * `bucket`              - Bucket to write the object into.
+    /// * `key`                 - Key to write the object into.
+    /// * `part_size`           - How large, in bytes, each part should be.
+    /// * `max_uploading_parts` - How many parts to upload concurrently.
+    #[instrument(skip(client))]
+    pub async fn new(
+        client: &'a Client,
+        dst: S3Object,
+        part_size: usize,
+        max_uploading_parts: Option<usize>,
+    ) -> anyhow::Result<AsyncMultipartUpload<'a>> {
+        event!(Level::DEBUG, "New AsyncMultipartUpload");
+        if part_size < MIN_PART_SIZE {
+            anyhow::bail!("part_size was {part_size}, can not be less than {MIN_PART_SIZE}")
+        }
+        if part_size > MAX_PART_SIZE {
+            anyhow::bail!("part_size was {part_size}, can not be more than {MAX_PART_SIZE}")
+        }
+
+        if max_uploading_parts.unwrap_or(DEFAULT_MAX_UPLOADING_PARTS) == 0 {
+            anyhow::bail!("Max uploading parts must not be 0")
+        }
+
+        let result = client
+            .create_multipart_upload()
+            .bucket(&dst.bucket)
+            .key(&dst.key)
+            .acl(ObjectCannedAcl::BucketOwnerFullControl)
+            .send()
+            .await?;
+
+        let upload_id = result.upload_id().context("Expected Upload Id")?;
+
+        Ok(AsyncMultipartUpload {
+            config: AsyncMultipartUploadConfig {
+                client,
+                dst,
+                upload_id: upload_id.into(),
+                part_size,
+                max_uploading_parts: max_uploading_parts.unwrap_or(DEFAULT_MAX_UPLOADING_PARTS),
+            },
+            state: AsyncMultipartUploadState::Writing {
+                uploads: vec![],
+                buffer: Vec::with_capacity(part_size),
+                part_number: 1,
+                completed_parts: vec![],
+            },
+        })
+    }
+
+    #[instrument(skip(buffer))]
+    fn upload_part<'b>(
+        config: &AsyncMultipartUploadConfig,
+        buffer: Vec<u8>,
+        part_number: i32,
+    ) -> MultipartUploadFuture<'b> {
+        event!(Level::DEBUG, "Uploading Part");
+        config
+            .client
+            .upload_part()
+            .bucket(&config.dst.bucket)
+            .key(&config.dst.key)
+            .upload_id(&config.upload_id)
+            .part_number(part_number)
+            .body(ByteStream::from(buffer))
+            .send()
+            .map_ok(move |p| (p, part_number))
+            .boxed()
+    }
+
+    fn poll_all<T>(futures: &mut Vec<BoxFuture<T>>, cx: &mut Context) -> Vec<T> {
+        let mut pending = vec![];
+        let mut complete = vec![];
+
+        while let Some(mut f) = futures.pop() {
+            match Pin::new(&mut f).poll(cx) {
+                Poll::Ready(result) => complete.push(result),
+                Poll::Pending => pending.push(f),
+            }
+        }
+        futures.extend(pending);
+        complete
+    }
+
+    #[instrument]
+    fn try_collect_complete_parts(
+        complete_results: Vec<Result<(UploadPartOutput, i32), SdkError<UploadPartError>>>,
+    ) -> Result<Vec<CompletedPart>, Error> {
+        complete_results
+            .into_iter()
+            .map(|r| r.map_err(|e| Error::new(ErrorKind::Other, e)))
+            .map(|r| {
+                r.map(|(c, part_number)| {
+                    CompletedPart::builder()
+                        .set_e_tag(c.e_tag)
+                        .part_number(part_number)
+                        .build()
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()
+    }
+
+    #[instrument]
+    fn complete_multipart_upload<'b>(
+        config: &AsyncMultipartUploadConfig,
+        completed_parts: Vec<CompletedPart>,
+    ) -> CompleteMultipartUploadFuture<'b> {
+        config
+            .client
+            .complete_multipart_upload()
+            .key(&config.dst.key)
+            .bucket(&config.dst.bucket)
+            .upload_id(&config.upload_id)
+            .multipart_upload(
+                CompletedMultipartUpload::builder()
+                    .set_parts(Some(completed_parts))
+                    .build(),
+            )
+            .send()
+            .boxed()
+    }
+
+    #[instrument(skip(uploads))]
+    fn check_uploads(
+        uploads: &mut Vec<MultipartUploadFuture<'a>>,
+        completed_parts: &mut Vec<CompletedPart>,
+        cx: &mut Context,
+    ) -> Result<(), Error> {
+        let complete_results = AsyncMultipartUpload::poll_all(uploads, cx);
+        let new_completed_parts =
+            AsyncMultipartUpload::try_collect_complete_parts(complete_results)?;
+        completed_parts.extend(new_completed_parts);
+        Ok(())
+    }
+}
+
+impl<'a> AsyncWrite for AsyncMultipartUpload<'a> {
+    #[instrument(skip(self, cx, buf))]
+    fn poll_write(
+        mut self: Pin<&mut AsyncMultipartUpload<'a>>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, Error>> {
+        // I'm not sure how to work around borrow of two disjoint fields.
+        // I had lifetime issues trying to implement Split Borrows
+        event!(Level::DEBUG, "Polling write");
+        let config = self.config.clone();
+        match &mut self.state {
+            AsyncMultipartUploadState::Writing {
+                uploads,
+                buffer,
+                part_number,
+                completed_parts,
+            } => {
+                event!(Level::DEBUG, "Polling write while Writing");
+                //Poll current uploads to make space for in coming data
+                AsyncMultipartUpload::check_uploads(uploads, completed_parts, cx)?;
+                //only take enough bytes to fill remaining upload capacity
+                let upload_capacity = ((config.max_uploading_parts - uploads.len())
+                    * config.part_size)
+                    - buffer.len();
+                let bytes_to_write = std::cmp::min(upload_capacity, buf.len());
+                // No capacity to upload
+                if bytes_to_write == 0 {
+                    uploads.is_empty().then(|| cx.waker().wake_by_ref());
+                    return Poll::Pending;
+                }
+                buffer.extend(&buf[..bytes_to_write]);
+
+                //keep pushing uploads until the buffer is small than the part size
+                while buffer.len() >= config.part_size {
+                    event!(Level::DEBUG, "Starting a new part upload");
+                    let mut part = buffer.split_off(config.part_size);
+                    // We want to consume the first part of the buffer and upload it to S3.
+                    // The split_off call does this but it's the wrong way around.
+                    // Use `mem:swap` to reverse the two variables in place.
+                    std::mem::swap(buffer, &mut part);
+                    //Upload a new part
+                    let part_upload =
+                        AsyncMultipartUpload::upload_part(&config, part, *part_number);
+                    uploads.push(part_upload);
+                    *part_number += 1;
+                }
+                //Poll all uploads, remove complete and fetch their results.
+                AsyncMultipartUpload::check_uploads(uploads, completed_parts, cx)?;
+                //Return number of bytes written from the input
+                Poll::Ready(Ok(bytes_to_write))
+            }
+            _ => Poll::Ready(Err(Error::new(
+                ErrorKind::Other,
+                "Attempted to .write() after .close().",
+            ))),
+        }
+    }
+
+    #[instrument(skip(self, cx))]
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        //Ensure all pending uploads are completed.
+        match &mut self.state {
+            AsyncMultipartUploadState::Writing {
+                uploads,
+                completed_parts,
+                ..
+            } => {
+                event!(Level::DEBUG, "Flushing Multipart Uploads");
+                //Poll uploads and mark as completed
+                AsyncMultipartUpload::check_uploads(uploads, completed_parts, cx)?;
+                if uploads.is_empty() {
+                    event!(Level::DEBUG, "All part uploads are complete");
+                    Poll::Ready(Ok(()))
+                } else {
+                    event!(Level::DEBUG, "Waiting for uploads to complete");
+                    //Assume that polled futures will trigger a wake
+                    Poll::Pending
+                }
+            }
+            _ => Poll::Ready(Err(Error::new(
+                ErrorKind::Other,
+                "Attempted to .flush() writer after .close().",
+            ))),
+        }
+    }
+
+    #[instrument(skip(self, cx))]
+    fn poll_close<'b>(
+        mut self: Pin<&'b mut AsyncMultipartUpload<'a>>,
+        cx: &'b mut Context<'_>,
+    ) -> Poll<Result<(), Error>> {
+        event!(Level::DEBUG, "Closing Multipart Uploads");
+        let config = self.config.clone();
+        match &mut self.state {
+            AsyncMultipartUploadState::Writing {
+                buffer,
+                uploads,
+                completed_parts,
+                part_number,
+            } => {
+                event!(Level::DEBUG, "Creating final Part Upload");
+                //make space for final upload
+                AsyncMultipartUpload::check_uploads(uploads, completed_parts, cx)?;
+                if config.max_uploading_parts - uploads.len() == 0 {
+                    event!(Level::DEBUG, "Waiting for available upload capacity");
+                    return Poll::Pending;
+                }
+                if !buffer.is_empty() {
+                    let buff = mem::take(buffer);
+                    let part = AsyncMultipartUpload::upload_part(&config, buff, *part_number);
+                    uploads.push(part);
+                }
+                //Poll all uploads, remove complete and fetch their results.
+                AsyncMultipartUpload::check_uploads(uploads, completed_parts, cx)?;
+                // If no remaining uploads then trigger a wake to move to next state
+                uploads.is_empty().then(|| cx.waker().wake_by_ref());
+                // Change state to Completing parts
+                self.state = AsyncMultipartUploadState::CompletingParts {
+                    uploads: mem::take(uploads),
+                    completed_parts: mem::take(completed_parts),
+                };
+                Poll::Pending
+            }
+            AsyncMultipartUploadState::CompletingParts {
+                uploads,
+                completed_parts,
+            } if uploads.is_empty() => {
+                event!(
+                    Level::DEBUG,
+                    "AsyncS3Upload all parts uploaded, Completing Upload"
+                );
+                //Once uploads are empty change state to Completing
+                let mut completed_parts = mem::take(completed_parts);
+                // This was surprising but was needed to complete the upload.
+                completed_parts.sort_by_key(|p| p.part_number());
+                let completing =
+                    AsyncMultipartUpload::complete_multipart_upload(&config, completed_parts);
+                self.state = AsyncMultipartUploadState::Completing(completing);
+                // Trigger a wake to run with new state and poll the future
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            AsyncMultipartUploadState::CompletingParts {
+                uploads,
+                completed_parts,
+            } => {
+                event!(
+                    Level::DEBUG,
+                    "AsyncS3Upload Waiting for All Parts to Upload"
+                );
+                //Poll all uploads, remove complete and fetch their results.
+                AsyncMultipartUpload::check_uploads(uploads, completed_parts, cx)?;
+                //Trigger a wake if all uploads have completed
+                uploads.is_empty().then(|| cx.waker().wake_by_ref());
+                Poll::Pending
+            }
+            AsyncMultipartUploadState::Completing(fut) => {
+                //use ready! macro to wait for complete uploaded to be done
+                //ready! is like the ? but for Poll objects returning `Polling` if not Ready
+                event!(Level::DEBUG, "Waiting for upload complete to finish");
+                let result = ready!(Pin::new(fut).poll(cx))
+                    .map(|_| ())
+                    .map_err(|e| Error::new(ErrorKind::Other, e)); //set state to closed
+                self.state = AsyncMultipartUploadState::Closed;
+                Poll::Ready(result)
+            }
+            AsyncMultipartUploadState::Closed => Poll::Ready(Err(Error::new(
+                ErrorKind::Other,
+                "Attempted to .close() writer after .close().",
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_part_size_too_small() {
+        let shared_config = aws_config::load_from_env().await;
+        let client = aws_sdk_s3::Client::new(&shared_config);
+        let dst = S3Object::new("bucket", "key");
+        assert!(AsyncMultipartUpload::new(&client, dst, 0_usize, None)
+            .await
+            .is_err())
+    }
+
+    #[tokio::test]
+    async fn test_part_size_too_big() {
+        let shared_config = aws_config::load_from_env().await;
+        let client = aws_sdk_s3::Client::new(&shared_config);
+        let dst = S3Object::new("bucket", "key");
+        assert!(
+            AsyncMultipartUpload::new(&client, dst, 5 * GIB as usize + 1, None)
+                .await
+                .is_err()
+        )
+    }
+
+    #[tokio::test]
+    async fn test_max_uploading_parts_is_zero() {
+        let shared_config = aws_config::load_from_env().await;
+        let client = aws_sdk_s3::Client::new(&shared_config);
+        let dst = S3Object::new("bucket", "key");
+        assert!(
+            AsyncMultipartUpload::new(&client, dst, 5 * MIB as usize, Some(0))
+                .await
+                .is_err()
+        )
+    }
+}

--- a/src/s3/async_multipart_put_object.rs
+++ b/src/s3/async_multipart_put_object.rs
@@ -323,8 +323,12 @@ impl<'a> AsyncWrite for AsyncMultipartUpload<'a> {
                     //Polled futures will trigger a wake
                     Poll::Pending
                 }
-            }
-            _ => Poll::Ready(Err(Error::new(
+            },
+            AsyncMultipartUploadState::None => Poll::Ready(Err(Error::new(
+                ErrorKind::Other,
+                "Attempted to .write() when state is None",
+            ))),
+             _ => Poll::Ready(Err(Error::new(
                 ErrorKind::Other,
                 "Attempted to .flush() writer after .close().",
             ))),

--- a/src/s3/async_multipart_put_object.rs
+++ b/src/s3/async_multipart_put_object.rs
@@ -77,7 +77,7 @@ enum AsyncMultipartUploadState<'a> {
 /// let buffer_len = 6 * 1_048_576;
 /// // Each part is uploaded as it's available
 /// writer.write_all(&vec![0; buffer_len]).await.unwrap();
-/// 
+///
 /// // The pending parts are uploaded and the multipart upload is completed
 /// // on close.
 /// writer.close().await.unwrap();
@@ -323,12 +323,12 @@ impl<'a> AsyncWrite for AsyncMultipartUpload<'a> {
                     //Polled futures will trigger a wake
                     Poll::Pending
                 }
-            },
+            }
             AsyncMultipartUploadState::None => Poll::Ready(Err(Error::new(
                 ErrorKind::Other,
                 "Attempted to .write() when state is None",
             ))),
-             _ => Poll::Ready(Err(Error::new(
+            _ => Poll::Ready(Err(Error::new(
                 ErrorKind::Other,
                 "Attempted to .flush() writer after .close().",
             ))),
@@ -625,5 +625,4 @@ mod tests {
         assert!(upload.write_all(&vec![0; buffer_len]).await.is_err());
         Ok(())
     }
-
 }

--- a/src/s3/async_multipart_put_object.rs
+++ b/src/s3/async_multipart_put_object.rs
@@ -107,9 +107,11 @@ impl<'a> AsyncMultipartUpload<'a> {
     /// Create a new [AsyncMultipartUpload].
     ///
     /// * `client`              - S3 client to use.
-    /// * `dst`              - The [S3Object] to write the object into.
-    /// * `part_size`           - How large, in bytes, each part should be.
-    /// * `max_uploading_parts` - How many parts to upload concurrently (defaults to 100).
+    /// * `dst`                 - The [S3Object] to write the object into.
+    /// * `part_size`           - How large, in bytes, each part should be. Must be 
+    /// larger than 5MIB and smaller that 5GIB.
+    /// * `max_uploading_parts` - How many parts to upload concurrently, 
+    /// Must be larger than 0 (defaults to 100).
     #[instrument(skip(client))]
     pub async fn new(
         client: &'a Client,
@@ -125,7 +127,8 @@ impl<'a> AsyncMultipartUpload<'a> {
             anyhow::bail!("part_size was {part_size}, can not be more than {MAX_PART_SIZE}")
         }
 
-        if max_uploading_parts.unwrap_or(DEFAULT_MAX_UPLOADING_PARTS) == 0 {
+        //Check that used did not send in invalid parameter
+        if let Some(0) = max_uploading_parts {
             anyhow::bail!("Max uploading parts must not be 0")
         }
 

--- a/src/s3/async_multipart_put_object.rs
+++ b/src/s3/async_multipart_put_object.rs
@@ -107,8 +107,7 @@ impl<'a> AsyncMultipartUpload<'a> {
     /// Create a new [AsyncMultipartUpload].
     ///
     /// * `client`              - S3 client to use.
-    /// * `bucket`              - Bucket to write the object into.
-    /// * `key`                 - Key to write the object into.
+    /// * `dst`              - The [S3Object] to write the object into.
     /// * `part_size`           - How large, in bytes, each part should be.
     /// * `max_uploading_parts` - How many parts to upload concurrently.
     #[instrument(skip(client))]

--- a/src/s3/mod.rs
+++ b/src/s3/mod.rs
@@ -16,8 +16,12 @@ use crate::localstack;
 ///
 pub use aws_sdk_s3::Client;
 
+mod async_multipart_put_object;
 mod async_put_object;
+mod s3_object;
+pub use async_multipart_put_object::AsyncMultipartUpload;
 pub use async_put_object::AsyncPutObject;
+pub use s3_object::S3Object;
 
 /// Create an S3 client with LocalStack support.
 ///

--- a/src/s3/mod.rs
+++ b/src/s3/mod.rs
@@ -157,8 +157,21 @@ pub async fn get_object(
 mod test {
     use super::*;
     use aws_config;
+    use aws_sdk_s3::error::CreateBucketError;
     use serial_test::serial;
     use tokio;
+    use std::collections::hash_map::DefaultHasher;
+    use anyhow::Result;
+    use aws_sdk_s3::Client;
+    use rand_chacha::ChaCha8Rng;
+    use rand::distributions::{Alphanumeric, DistString};
+    use rand::Rng;
+    use std::hash::{Hash, Hasher};
+    use rand::SeedableRng;
+    use crate::s3::S3Object;
+    use aws_sdk_s3::model;
+    use aws_sdk_s3::error::CreateBucketErrorKind;
+
 
     #[tokio::test]
     #[serial]
@@ -166,6 +179,48 @@ mod test {
         let shared_config = aws_config::load_from_env().await;
         #[allow(deprecated)]
         get_client(&shared_config).unwrap();
+    }
+
+    pub async fn create_bucket(client: &Client, bucket: &str) -> Result<()> {
+        let constraint = model::CreateBucketConfiguration::builder()
+            .location_constraint(model::BucketLocationConstraint::ApSoutheast2).build();
+        match client.create_bucket().bucket(bucket)
+            .create_bucket_configuration(constraint)
+            .send().await {
+                Ok(_) => Ok::<(), anyhow::Error>(()),
+                Err(SdkError::ServiceError { err: CreateBucketError{kind: CreateBucketErrorKind::BucketAlreadyOwnedByYou(_), ..}, .. }) =>{
+                    Ok::<(),anyhow::Error>(())
+                },
+                Err(e) => Err(anyhow::Error::from(e))
+            }
+    }
+    
+    pub fn seeded_rng<H: Hash + ?Sized>(seed: &H) -> impl Rng {
+        let mut hasher = DefaultHasher::new();
+        seed.hash(&mut hasher);
+        ChaCha8Rng::seed_from_u64(hasher.finish())
+    }
+    
+    
+    pub fn gen_random_file_name<R: Rng>(rng: &mut R) -> String {
+        Alphanumeric.sample_string(rng, 16)
+    }
+    
+    
+    pub async fn fetch_bytes(client: &Client, obj: &S3Object) -> Result<Vec<u8>> {
+        Ok(client
+            .get_object()
+            .bucket(&obj.bucket)
+            .key(&obj.key)
+            .send()
+            .await
+            .expect("Expceted dst key to exist")
+            .body
+            .collect()
+            .await
+            .expect("Expected a body")
+            .into_bytes()
+            .into())
     }
 }
 

--- a/src/s3/mod.rs
+++ b/src/s3/mod.rs
@@ -221,7 +221,7 @@ mod test {
             .key(&obj.key)
             .send()
             .await
-            .expect("Expceted dst key to exist")
+            .expect("Expected dst key to exist")
             .body
             .collect()
             .await

--- a/src/s3/s3_object.rs
+++ b/src/s3/s3_object.rs
@@ -1,0 +1,131 @@
+use std::str::FromStr;
+
+use anyhow::{bail, Context, Error};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+/// A bucket key pair for a S3Object, with conversion from S3 urls.
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct S3Object {
+    /// The bucket the object is in.
+    pub bucket: String,
+    /// The key the in the bucket for the object.
+    pub key: String,
+}
+
+impl S3Object {
+    /// Create a new [S3Object] using anything which can be
+    /// treated as [&str].  Any leading `/` will be trimmed from
+    /// the key.  No validation is done against the bucket or key
+    /// to ensure they meet the AWS requirements.
+    pub fn new(bucket: impl AsRef<str>, key: impl AsRef<str>) -> Self {
+        S3Object {
+            bucket: bucket.as_ref().to_owned(),
+            key: key.as_ref().trim_start_matches('/').to_owned(),
+        }
+    }
+}
+
+/// Convert from an [Url] into a [S3Object]. The scheme
+/// must be `s3` and the `path` must not be empty.
+impl TryFrom<Url> for S3Object {
+    type Error = Error;
+
+    fn try_from(value: Url) -> Result<Self, Self::Error> {
+        if value.scheme() != "s3" {
+            bail!("S3 URL must have a scheme of s3")
+        }
+        let bucket = value.host_str().context("S3 URL must have host")?;
+        let key = value.path();
+
+        if key.is_empty() {
+            bail!("S3 URL must have a path")
+        }
+        Ok(S3Object::new(bucket, key))
+    }
+}
+
+/// Convert from a [&str] into a [S3Object].
+/// The [&str] must be a valid `S3` [Url].
+impl TryFrom<&str> for S3Object {
+    type Error = Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse::<Url>()?.try_into()
+    }
+}
+
+/// Covert from [String] into a [S3Object].
+/// The [String] must be a valid `S3` [Url].
+impl TryFrom<String> for S3Object {
+    type Error = Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse::<Url>()?.try_into()
+    }
+}
+
+/// Covert from [&str] into a [S3Object].
+/// The [&str] must be a valid `S3` [Url].
+impl FromStr for S3Object {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        value.parse::<Url>()?.try_into()
+    }
+}
+
+/// Converts from a [S3Object] into a [Url].
+/// If the [S3Object] holds an invalid path or
+/// domain the conversion will fail.
+impl TryFrom<S3Object> for Url {
+    type Error = url::ParseError;
+    fn try_from(obj: S3Object) -> std::result::Result<Self, Self::Error> {
+        Url::parse(&format!("s3://{}/{}", obj.bucket, obj.key))
+    }
+}
+
+/// Converts from a [S3Object] into a [Url].
+/// If the [S3Object] holds an invalid path or
+/// domain the conversion will fail.
+impl TryFrom<&S3Object> for Url {
+    type Error = url::ParseError;
+    fn try_from(obj: &S3Object) -> std::result::Result<Self, Self::Error> {
+        Url::parse(&format!("s3://{}/{}", obj.bucket, obj.key))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_s3_tryfrom() {
+        let bucket = "test-bucket.to_owned()";
+        let key = "test-key";
+        let url: url::Url = format!("s3://{bucket}/{key}")
+            .parse()
+            .expect("Expected successful URL parsing");
+        let obj: S3Object = url.try_into().expect("Expected successful URL conversion");
+        assert_eq!(bucket, obj.bucket);
+        assert_eq!(key, obj.key);
+    }
+
+    #[test]
+    fn test_s3_tryfrom_no_path() {
+        let url: url::Url = "s3://test-bucket"
+            .parse()
+            .expect("Expected successful URL parsing");
+        let result: Result<S3Object> = url.try_into();
+        assert!(result.is_err())
+    }
+
+    #[test]
+    fn test_s3_tryfrom_file_url() {
+        let url: url::Url = "file://path/to/file"
+            .parse()
+            .expect("Expected successful URL parsing");
+        let result: Result<S3Object> = url.try_into();
+        assert!(result.is_err())
+    }
+}

--- a/src/s3/s3_object.rs
+++ b/src/s3/s3_object.rs
@@ -55,7 +55,7 @@ impl TryFrom<&str> for S3Object {
     }
 }
 
-/// Covert from [String] into a [S3Object].
+/// Convert from [String] into a [S3Object].
 /// The [String] must be a valid `S3` [Url].
 impl TryFrom<String> for S3Object {
     type Error = Error;

--- a/src/s3/s3_object.rs
+++ b/src/s3/s3_object.rs
@@ -65,7 +65,7 @@ impl TryFrom<String> for S3Object {
     }
 }
 
-/// Covert from [&str] into a [S3Object].
+/// Convert from [&str] into a [S3Object].
 /// The [&str] must be a valid `S3` [Url].
 impl FromStr for S3Object {
     type Err = Error;

--- a/src/s3/s3_object.rs
+++ b/src/s3/s3_object.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use anyhow::{bail, Context, Error};
+use anyhow::{bail, Context, Error, Result};
 use serde::{Deserialize, Serialize};
 use url::Url;
 


### PR DESCRIPTION
## What

Added a AsyncWrite implementation around S3 Multipart Uploads.  Bytes are buffered
until the configured part size is reached after which point those bytes are sent to
S3 while concurrently accumulating, and submitting, subsequent bytes.

Calling `flush` on the AysncWrite will cause all in progress part uploads to complete.

Calling `close` on the AsyncWrite will write the final bytes as a part and then complete
the multipart upload.

## Why

S3 does not allow `"Transfer-Encoding: Chunked"` for Put Object request therefore the
Content-Length must be known.  For streaming requests, where data is being streamed out
of the process and into S3, this means the memory limit of the process must be set to the
largest expected output file size.  When using Serverless functions and using the Put Object
API the Lambdas need to be over provisioned with memory to handle the largest files which
increases cost.

The AyncMultiPartUpload allows streams of bytes to be written into S3 as a series of `parts` 
which means the memory usage is constrained by the number of concurrent part uploads.  Both
the part size as well as the number of concurrent uploads can be configured. By removing the
link between maximum memory and input size Serverless functions can be configured with a much
lower memory and therefore operate at a lower cost.

## Concerns
This crate has the integration tests with the source code rather than in the `tests` directory
as described [here](https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html).
I did try to implement the tests for this module in the `tests` directory but getting the correct localstack endpoints for the client and waiting for localstack to start took longer than anticipated.