### PR TITLE
bug/state-swap-low-throughput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.9.1
+
 - Set AsyncMultipartUpload state back when there is no capacity.
 
 ## 0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Set AsyncMultipartUpload state back when there is no capacity.
+
 ## 0.9.0
 
  - Added AsyncMultipartUpload.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cobalt-aws"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["harrison.ai Data Engineering <dataengineering@harrison.ai>"]
 edition = "2021"
 description = "This library provides a collection of wrappers around the aws-sdk-rust and lambda_runtime packages."

--- a/licenses/licenses.html
+++ b/licenses/licenses.html
@@ -76,7 +76,7 @@
                     <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-types 0.51.0</a></li>
                     <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-xml 0.51.0</a></li>
                     <li><a href=" https://github.com/awslabs/smithy-rs ">aws-types 0.51.0</a></li>
-                    <li><a href=" https://github.com/harrison-ai/cobalt-aws/ ">cobalt-aws 0.9.0</a></li>
+                    <li><a href=" https://github.com/harrison-ai/cobalt-aws/ ">cobalt-aws 0.9.1</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License

--- a/src/s3/async_multipart_put_object.rs
+++ b/src/s3/async_multipart_put_object.rs
@@ -644,7 +644,7 @@ mod tests {
     #[named]
     async fn test_put_16mb_single_upload() {
         let client = localstack_test_client().await;
-        let test_bucket = "test-bucket";
+        let test_bucket = "test-multipart-bucket";
         let mut rng = seeded_rng(function_name!());
         let dst_key = gen_random_file_name(&mut rng);
 


### PR DESCRIPTION
## What

There is a bug in the AsyncMultipartPut code where the
state remains set to None when the number concurent part uploads
is reached.

The PR also creates version 0.9.1 which should contain this fix.


