### PR TITLE
feat: multipart session resumption #FRA-922

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.9.2
+
+- Add support to continue an existing AsyncMultipartUpload.
+
 ## 0.9.1
 
 - Set AsyncMultipartUpload state back when there is no capacity.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cobalt-aws"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["harrison.ai Data Engineering <dataengineering@harrison.ai>"]
 edition = "2021"
 description = "This library provides a collection of wrappers around the aws-sdk-rust and lambda_runtime packages."

--- a/src/s3/async_multipart_put_object.rs
+++ b/src/s3/async_multipart_put_object.rs
@@ -207,35 +207,11 @@ impl<'a> AsyncMultipartUpload<'a> {
                 // Part has Option<&str> but CompletedPart has Option<String>
                 // Convert any &str's to String's but retain them as Options still
 
-                let e_tag = if let Some(e_tag) = part.e_tag() {
-                    Some(e_tag.to_string())
-                } else {
-                    None
-                };
-
-                let checksum_crc32 = if let Some(checksum_crc32) = part.checksum_crc32() {
-                    Some(checksum_crc32.to_string())
-                } else {
-                    None
-                };
-
-                let checksum_crc32_c = if let Some(checksum_crc32_c) = part.checksum_crc32_c() {
-                    Some(checksum_crc32_c.to_string())
-                } else {
-                    None
-                };
-
-                let checksum_sha1 = if let Some(checksum_sha1) = part.checksum_sha1() {
-                    Some(checksum_sha1.to_string())
-                } else {
-                    None
-                };
-
-                let checksum_sha256 = if let Some(checksum_sha256) = part.checksum_sha256() {
-                    Some(checksum_sha256.to_string())
-                } else {
-                    None
-                };
+                let e_tag = part.e_tag().map(|s| s.to_string());
+                let checksum_crc32 = part.checksum_crc32().map(|s| s.to_string());
+                let checksum_crc32_c = part.checksum_crc32_c().map(|s| s.to_string());
+                let checksum_sha1 = part.checksum_sha1().map(|s| s.to_string());
+                let checksum_sha256 = part.checksum_sha256().map(|s| s.to_string());
 
                 CompletedPart::builder()
                     .set_e_tag(e_tag)
@@ -267,7 +243,7 @@ impl<'a> AsyncMultipartUpload<'a> {
                 uploads: vec![],
                 buffer: Vec::with_capacity(part_size),
                 part_number: latest_part_number,
-                completed_parts: completed_parts,
+                completed_parts,
             },
         })
     }

--- a/src/s3/async_multipart_put_object.rs
+++ b/src/s3/async_multipart_put_object.rs
@@ -686,7 +686,7 @@ mod tests {
             .unwrap();
         resumed_upload.close().await.unwrap();
 
-        // body with one single part
+        // body with 2 parts uploaded in different upload instances
         let final_body = fetch_bytes(&client, &dst).await.unwrap();
         assert_eq!(final_body.len(), 2_usize * buffer_len);
         Ok(())

--- a/src/s3/async_multipart_put_object.rs
+++ b/src/s3/async_multipart_put_object.rs
@@ -187,14 +187,6 @@ impl<'a> AsyncMultipartUpload<'a> {
             anyhow::bail!("Max uploading parts must not be 0")
         }
 
-        // let result = client
-        //     .create_multipart_upload()
-        //     .bucket(&dst.bucket)
-        //     .key(&dst.key)
-        //     .acl(ObjectCannedAcl::BucketOwnerFullControl)
-        //     .send()
-        //     .await?;
-
         let list_parts_result = client
             .list_parts()
             .bucket(&dst.bucket)


### PR DESCRIPTION
## What

Adds the ability to resume an existing multipart upload, also adding a helper to expose the `upload_id` from a multipart upload.

## Why

So we can have a long-lived multipart upload that we can share around!
