### PR TITLE
Updated rust to 1.67-1.0 and changed version from 3.7 to 3.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
-version: '3.7'
+version: '3.8'
 services:
 
   cargo:
-    image: harrisonai/rust:1.63-1.1
+    image: harrisonai/rust:1.67-1.0
     entrypoint: cargo
     volumes:
       - '~/.cargo/registry:/usr/local/cargo/registry'


### PR DESCRIPTION
[This PR](https://github.com/harrison-ai/cobalt-aws/pull/196) failed the checks due to the rust version being 1.63.1.1. [Rust has now been updated](https://github.com/harrison-ai/dataeng-tooling-rust/commit/177e97702875760735d3143a610c254db1b1fcb0) 

This change reflects the new rust. 