### PR TITLE
Update change log to prepare for version 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Updated `aws-sdk-sqs` to 0.24.0
   - Updated `aws-smithy-http` 0.54.4
   - Updated `aws-types` to 0.54.1
-- Updated `rust crate tokio` to 1.26.0
-- Updated `rust crate clap` to 4.1.8
-- Updated `rust crate bytesize` to 1.2.0
-- Updated `rust crate serial_test` to v1
+- Updated rust crate `tokio` to 1.26.0
+- Updated rust crate `clap` to 4.1.8
+- Updated rust crate `bytesize` to 1.2.0
+- Updated rust crate `serial_test` to v1
 - Updated `localstack docker tag` to 1.4.0
 - Updated `python docker tag` to v3.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated rust crate `clap` to 4.1.8
 - Updated rust crate `bytesize` to 1.2.0
 - Updated rust crate `serial_test` to v1
-- Updated `localstack docker tag` to 1.4.0
-- Updated `python docker tag` to v3.11
 
 ## 0.9.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.10.0
+
+- Replaced depreciated `Endpoint` with endpoint_url, disabled use of `Endpoint 2.0`
+- Updated `aws-config ` to 0.54.1
+- Updated `aws-sdk-athena` to 0.24.0
+- Updated `aws-sdk-s3` to 0.24.0
+- Updated `aws-sdk-sqs` to 0.24.0
+- Updated `aws-smithy-http` 0.54.4
+- Updated `aws-types` to 0.54.1
+- Updated `rust crate tokio` to 1.26.0
+- Updated `rust crate clap` to 4.1.8
+- Updated `rust crate bytesize` to 1.2.0
+- Updated `rust crate serial_test` to v1
+- Updated `localstack docker tag` to 1.4.0
+- Updated `python docker tag` to v3.11
+
 ## 0.9.2
 
 - Add support to continue an existing AsyncMultipartUpload.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.10.0
 
-- Replaced depreciated `Endpoint` with endpoint_url, disabled use of `Endpoint 2.0`
-- Updated `aws-config ` to 0.54.1
-- Updated `aws-sdk-athena` to 0.24.0
-- Updated `aws-sdk-s3` to 0.24.0
-- Updated `aws-sdk-sqs` to 0.24.0
-- Updated `aws-smithy-http` 0.54.4
-- Updated `aws-types` to 0.54.1
+- Updated various AWS SDK dependencies. Note that the new versions include significant changes to endpoint URL resolution, which may introduce breaking changes for consumers; see the [`aws-sdk-rust` release notes](https://github.com/awslabs/aws-sdk-rust/releases/tag/release-2023-01-13) for details.
+  - Updated `aws-config ` to 0.54.1
+  - Updated `aws-sdk-athena` to 0.24.0
+  - Updated `aws-sdk-s3` to 0.24.0
+  - Updated `aws-sdk-sqs` to 0.24.0
+  - Updated `aws-smithy-http` 0.54.4
+  - Updated `aws-types` to 0.54.1
 - Updated `rust crate tokio` to 1.26.0
 - Updated `rust crate clap` to 4.1.8
 - Updated `rust crate bytesize` to 1.2.0


### PR DESCRIPTION
## What

Updated dependencies, and not using `Endpoint 2.0` in this version

## Why

To prepare for new `cobalt-aws` version
