### PR TITLE
Update cargo.toml and licenses report v0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cobalt-aws"
-version = "0.9.2"
+version = "0.10.0"
 authors = ["harrison.ai Data Engineering <dataengineering@harrison.ai>"]
 edition = "2021"
 description = "This library provides a collection of wrappers around the aws-sdk-rust and lambda_runtime packages."

--- a/licenses/licenses.html
+++ b/licenses/licenses.html
@@ -78,7 +78,7 @@
                     <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-types 0.54.4</a></li>
                     <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-xml 0.54.4</a></li>
                     <li><a href=" https://github.com/awslabs/smithy-rs ">aws-types 0.54.1</a></li>
-                    <li><a href=" https://github.com/harrison-ai/cobalt-aws/ ">cobalt-aws 0.9.2</a></li>
+                    <li><a href=" https://github.com/harrison-ai/cobalt-aws/ ">cobalt-aws 0.10.0</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License


### PR DESCRIPTION
## What

Update the release version in cargo.toml and re-run `make licenses-report`

## Why

Po made silly mistakes

## Concerns

Po decides to code too late at night and isn't careful enough
