### PR TITLE
Update Rust docker image location.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
 
   cargo:
-    image: harrisonai/rust:1.67-1.0
+    image: ghcr.io/harrison-ai/rust:1.67-1
     entrypoint: cargo
     volumes:
       - '~/.cargo/registry:/usr/local/cargo/registry'


### PR DESCRIPTION
The rust docker images have moved to GHCR, update the reference to its new location per https://github.com/harrison-ai/dataeng-tooling-rust#rust-build-and-development-tooling-for-harrisonai

