### PR TITLE
feat: running_on_lambda()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+ - Added `running_on_lambda()` to support programs running both locally and on AWS Lambda.
+
 ## 0.10.0
 
 - Updated various AWS SDK dependencies. Note that the new versions include significant changes to endpoint URL resolution, which may introduce breaking changes for consumers; see the [`aws-sdk-rust` release notes](https://github.com/awslabs/aws-sdk-rust/releases/tag/release-2023-01-13) for details.
@@ -32,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  - Added AsyncMultipartUpload.
  - Add S3Object.
- - Updated `aws_lambda_events` to 0.7.2 
+ - Updated `aws_lambda_events` to 0.7.2
  - Updated `aws_lambda_runtime` to 0.7.1
  - Updated `aws-config` to 0.51.0
  - Updated `aws-sdk-athena` to 0.21.0

--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -21,6 +21,23 @@ use tracing_subscriber::filter::EnvFilter;
 // We provide this re-export so that the user doesn't need to have lambda_runtime as a direct dependency.
 pub use lambda_runtime::Error;
 
+#[derive(Debug, Parser)]
+struct CheckLambda {
+    #[arg(env)]
+    aws_lambda_function_name: Option<String>,
+}
+
+/// Determine whether the code is being executed within an AWS Lambda.
+///
+/// This function can be used to write binaries that are able to run both locally
+/// or as a Lambda function.
+pub fn running_on_lambda() -> Result<bool> {
+    let check_lambda = CheckLambda::try_parse_from(empty::<OsString>())
+        .context("An error occurred while parsing environment variables for message context.")?;
+    Ok(check_lambda.aws_lambda_function_name.is_some())
+}
+
+
 /// A required trait of the `Context` type used by message handler functions in [run_message_handler].
 ///
 /// All `Context` types must implement the implement the [LambdaContext::from_env] method for their corresponding `Env` type.

--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -37,7 +37,6 @@ pub fn running_on_lambda() -> Result<bool> {
     Ok(check_lambda.aws_lambda_function_name.is_some())
 }
 
-
 /// A required trait of the `Context` type used by message handler functions in [run_message_handler].
 ///
 /// All `Context` types must implement the implement the [LambdaContext::from_env] method for their corresponding `Env` type.


### PR DESCRIPTION
## What

This PR adds a function `running_on_lambda()`, which examines the environment variables to determine whether or not the binary is being run on AWS Lambda.

## Why

As part of the development cycle, needing to build an image and push it to AWS in order to run the handler can be time consuming, adding unnecessary friction to the dev cycle. This function gives an escape hatch to allow code to be run locally.

## Notes

Subsequent PRs will add support for actually executing the message handler locally. For now, this PR just allows us to determine the running environment.