### PR TITLE
feat: LocalContext and run_local_handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
  - Added `running_on_lambda()` to support programs running both locally and on AWS Lambda.
+ - Added `LocalContext` and `run_local_handler` to support executing message handlers locally.
 
 ## 0.10.0
 


### PR DESCRIPTION
## What

This PR adds a `LocalContext` trait and `run_local_handler()` function.

## Why

This functionality gives us a way to run a `message_handler` locally. Let gives us the flexibility to write tools that can be run either as a Lambda, or as a local CLI tool/
