### PR TITLE
chore: aws_lambda_events build time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ aws-sdk-s3 = "0.28.0"
 aws-sdk-sqs = "0.28.0"
 aws-smithy-http = "0.55.3"
 aws-types = "0.55.3"
-aws_lambda_events = "0.10.0"
+aws_lambda_events = { version = "0.10.0", default-features=false, features = ["sqs"]}
 lambda_runtime = "0.8.1"
 bytesize = "1.2.0"
 clap = { version = "4.3.17", features = ["derive", "env"] }


### PR DESCRIPTION
## Related Tasks

This PR is focused on optimizing build times locally and includes basic testing to validate the improvements. It also involves disabling default features on the `aws_lambda_event` crate and only enabling `sqs` events.

## Depends on

There are no other PRs that need to be merged before this one.

## What

Within this PR, the following changes have been made:

1. Disabled default features on `aws_lambda_event`: By disabling the default features, we ensure that no unnecessary features are included during the build process. This can significantly reduce compilation times and binary size.

2. Enabled only `sqs` events: For our specific use case, we only require `sqs` events from the `aws_lambda_event` crate. By enabling only this feature, we further optimize the crate for our requirements.

3. Basic Testing: Rudimentary basic testing was performed to validate the improvements in build times. The local build time of `cobolt-aws` was reduced from `15.4s` to `4.2s`. Specifically, the `aws_lambda_events` crate build time decreased from `9.4s` to `0.1s`, showcasing the substantial impact of our changes.

## Why

We are submitting this PR to address the issue of build times during local development. By customizing the features of the `aws_lambda_event` crate and conducting basic testing, we can confidently optimize the build process and improve development efficiency.