### PR TITLE
fix: Update compose to V2, deps excl AWS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.12.0
+
+ - Upgrades from Docker Compose V1 to Docker Compose V2 for developer tooling.
+ - Updates dependencies, excluding the AWS SDK, to their latest version. The AWS SDK update has a lot of breaking changes.
+ - Fixes a bug with `make test-examples` where destroying the previous localstack container wasn't removing the named volumes. This resulted in subsequent re-runs to error, as the queue being created already existed.
+ - Changes dependency versions to `major.minor` instead of `major.minor.build`, as the package is a library and we should let downstream packages select their desired build versions.
+
 ## 0.11.1
 
  - Fixed `run_local_handler` to support message handlers with return types other than `()`.
@@ -35,8 +42,6 @@ impl LambdaContext<Env, SqsEvent> for Context {
     - `aws-types = "0.55.3"`
     - `aws_lambda_events = "0.10.0"`
     - `lambda_runtime = "0.8.1"`
-
-
 
 ## 0.10.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cobalt-aws"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["harrison.ai Data Engineering <dataengineering@harrison.ai>"]
 edition = "2021"
 description = "This library provides a collection of wrappers around the aws-sdk-rust and lambda_runtime packages."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,32 +17,32 @@ include = [
 ]
 
 [dependencies]
-anyhow = "1.0.72"
-async-trait = "0.1.71"
-aws-config = "0.56.0"
-aws-sdk-athena = "0.29.0"
-aws-sdk-s3 = "0.29.0"
-aws-sdk-sqs = "0.29.0"
-aws-smithy-http = "0.56.0"
-aws-types = "0.56.0"
-aws_lambda_events = { version = "0.10.0", default-features=false, features = ["sqs"]}
-lambda_runtime = "0.8.1"
-bytesize = "1.2.0"
-clap = { version = "4.3.17", features = ["derive", "env"] }
-derivative = "2.2.0"
-futures = "0.3.28"
-http = "0.2.9"
-serde = "1.0.173"
-serde_json = "1.0.103"
-tokio = { version = "1.29.1", features=["macros"] }
-tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.17", features=["json", "env-filter"] }
-url = { version = "2.4.0", features = ["serde"] }
+anyhow = "1.0"
+async-trait = "0.1"
+aws-config = "0.56"
+aws-sdk-athena = "0.29"
+aws-sdk-s3 = "0.29"
+aws-sdk-sqs = "0.29"
+aws-smithy-http = "0.56"
+aws-types = "0.56"
+aws_lambda_events = { version = "0.10", default-features=false, features = ["sqs"]}
+lambda_runtime = "0.9"
+bytesize = "1.3"
+clap = { version = "4.4", features = ["derive", "env"] }
+derivative = "2.2"
+futures = "0.3"
+http = "0.2"
+serde = "1.0"
+serde_json = "1.0"
+tokio = { version = "1.35", features=["macros"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features=["json", "env-filter"] }
+url = { version = "2.4", features = ["serde"] }
 
 [dev-dependencies]
 function_name = "0.3.0"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
-reqwest = { version = "0.11.18", features=["json"] }
+reqwest = { version = "0.11.23", features=["json"] }
 serial_test = "2.0.0"
-tokio-test = "0.4.2"
+tokio-test = "0.4.3"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 UID = $(shell id -u)
-DCRUN = docker-compose run --rm --user $(UID)
+DCRUN = docker compose run --rm --user $(UID)
 
 .DEFAULT_GOAL := help
 

--- a/scripts/read_and_validate_logs.sh
+++ b/scripts/read_and_validate_logs.sh
@@ -1,6 +1,6 @@
 set -e
 
-DCRUN="docker-compose run --rm"
+DCRUN="docker compose run --rm"
 AWSLOCAL="$DCRUN awslocal"
 
 export EXAMPLE=hello_lambda

--- a/scripts/run_example.sh
+++ b/scripts/run_example.sh
@@ -9,12 +9,12 @@ export ENV="GREETING=hello"
 # Specify the message to send to the lambda
 export MESSAGE="{\"target\": \"world\"}"
 
-DCRUN="docker-compose run --rm"
+DCRUN="docker compose run --rm"
 AWSLOCAL="$DCRUN awslocal"
 
 # Restart the localstack daemon, to clear state.
-docker-compose down
-docker-compose up -d localstack
+docker compose down --volumes
+docker compose up -d localstack
 
 # TODO: cleanly wait for localstack to come up
 sleep 5


### PR DESCRIPTION
## What

* Upgrades from Docker Compose V1 to Docker Compose V2
* Updates dependencies excluding the AWS SDK to their latest version. The AWS SDK update has a lot of breaking changes.
* Fixes a bug with `make test-examples` where destroying the previous localstack container wasn't removing the named volumes. This resulted in subsequent re-runs to error, as the queue being created already existed.
* Changes dependency versions to `major.minor` instead of `major.minor.build`, as the package is a library and we should let downstream packages select their desired build versions.

## Why

To keep our dependencies up to date for security and performance, and to ensure our developer experience is kept up to date for testing.
