### PR TITLE
Upgrade AWS crates and localstack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ aws-smithy-runtime-api = "1.1.2"
 aws-smithy-async = "1.1.2"
 aws-types = "1.1.2"
 aws_lambda_events = { version = "0.13", default-features=false, features = ["sqs"]}
+bytes = "1.5.0"
 lambda_runtime = "0.9.0"
 bytesize = "1.3"
 clap = { version = "4.4", features = ["derive", "env"] }
@@ -39,7 +40,6 @@ tokio = { version = "1.35", features=["macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features=["json", "env-filter"] }
 url = { version = "2.5", features = ["serde"] }
-bytes = "1.5.0"
 
 [dev-dependencies]
 function_name = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ bytesize = "1.3"
 clap = { version = "4.4", features = ["derive", "env"] }
 derivative = "2.2"
 futures = "0.3"
-http = "0.2"
+http = "1.0"
 serde = "1.0"
 serde_json = "1.0"
 tokio = { version = "1.35", features=["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,15 @@ include = [
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-aws-config = "0.56"
-aws-sdk-athena = "0.29"
-aws-sdk-s3 = "0.29"
-aws-sdk-sqs = "0.29"
-aws-smithy-http = "0.56"
-aws-types = "0.56"
+aws-sdk-athena = "1.10.0"
+aws-config = { version = "1.1.2", features = ["behavior-version-latest"] }
+aws-sdk-s3 = "1.12.0"
+aws-sdk-sqs = "1.10.0"
+aws-smithy-runtime-api = "1.1.2"
+aws-smithy-async = "1.1.2"
+aws-types = "1.1.2"
 aws_lambda_events = { version = "0.13", default-features=false, features = ["sqs"]}
-lambda_runtime = "0.9"
+lambda_runtime = "0.9.0"
 bytesize = "1.3"
 clap = { version = "4.4", features = ["derive", "env"] }
 derivative = "2.2"
@@ -38,6 +39,7 @@ tokio = { version = "1.35", features=["macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features=["json", "env-filter"] }
 url = { version = "2.5", features = ["serde"] }
+bytes = "1.5.0"
 
 [dev-dependencies]
 function_name = "0.3.0"

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test:
 # Sleep for 20s in between to let CI complete execution
 test-examples:
 	./scripts/run_example.sh
-	sleep 20
+	sleep 1
 	./scripts/read_and_validate_logs.sh
 
 ## fmt:          format all code using standard conventions

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,8 @@ test:
 	$(DCRUN) cargo test
 
 ## test-examples:	test example code using localstack
-# Sleep for 20s in between to let CI complete execution
 test-examples:
 	./scripts/run_example.sh
-	sleep 1
 	./scripts/read_and_validate_logs.sh
 
 ## fmt:          format all code using standard conventions

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     build:
       context: scripts
       dockerfile: Dockerfile-awslocal
-    entrypoint: awslocal 
+    entrypoint: awslocal
     volumes:
       - '.:/app'
     working_dir: '/app'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ version: '3.8'
 services:
 
   cargo:
-    image: ghcr.io/harrison-ai/rust:1.75-1.0
+    build:
+      dockerfile: rust-dev.dockerfile
+      context: .
     entrypoint: cargo
     volumes:
       - '~/.cargo/registry:/usr/local/cargo/registry'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
 
   cargo:
-    image: ghcr.io/harrison-ai/rust:1.70-1
+    image: ghcr.io/harrison-ai/rust:1.75-1.0
     entrypoint: cargo
     volumes:
       - '~/.cargo/registry:/usr/local/cargo/registry'
@@ -13,6 +13,8 @@ services:
       - AWS_DEFAULT_REGION=ap-southeast-2
       - AWS_ACCESS_KEY_ID=placeholder
       - AWS_SECRET_ACCESS_KEY=placeholder
+        #- RUST_LOG=debug
+        #- RUST_BACKTRACE=full
     depends_on:
       localstack:
         condition: service_healthy
@@ -21,7 +23,7 @@ services:
     build:
       context: scripts
       dockerfile: Dockerfile-awslocal
-    entrypoint: awslocal
+    entrypoint: awslocal 
     volumes:
       - '.:/app'
     working_dir: '/app'
@@ -30,12 +32,13 @@ services:
       - AWS_DEFAULT_REGION=ap-southeast-2
       - AWS_ACCESS_KEY_ID=placeholder
       - AWS_SECRET_ACCESS_KEY=placeholder
+      - AWS_PAGER=""
     depends_on:
       - localstack
 
   localstack:
-    image: localstack/localstack:1.4.0
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    image: localstack/localstack:3.0.2
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range
@@ -49,10 +52,11 @@ services:
       - LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY-}  # only required for Pro
       - DOCKER_HOST=unix:///var/run/docker.sock
       - AWS_DEFAULT_REGION=ap-southeast-2
+      - DEFAULT_REGION=ap-southeast-2
     volumes:
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
-      - "./scripts/init-localstack.sh:/docker-entrypoint-initaws.d/init-localstack.sh"
+      - "./scripts/init-localstack.sh:/etc/localstack/init/ready.d/init-aws.sh"
       - "./test-data:/tmp/test-data"
     healthcheck:
       test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,6 @@ services:
       - LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY-}  # only required for Pro
       - DOCKER_HOST=unix:///var/run/docker.sock
       - AWS_DEFAULT_REGION=ap-southeast-2
-      - DEFAULT_REGION=ap-southeast-2
     volumes:
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/rust-dev.dockerfile
+++ b/rust-dev.dockerfile
@@ -1,0 +1,25 @@
+FROM ghcr.io/harrison-ai/rust:1.75-1.0
+
+# cargo deny version 0.14.3 in the rust base layer fails on cargo deny check with:
+# failed to fetch advisory database https://github.com/RustSec/advisory-db: An IO error occurred when talking to the server: error sending request for url (https://github.com/RustSec/advisory-db/info/refs?service=git-upload-pack): error trying to connect: invalid URL, scheme is not http
+#
+#Re Installing 0.14.3 or 0.14.2 results in this error on cargo deny check:
+#internal error: entered unreachable code: unable to find dependency valuable for tracing-core 0.1.32 (registry+https://github.com/rust-lang/crates.io-index) [
+#    NodeDep {
+#        name: "once_cell",
+#        pkg: PackageId {
+#            repr: "once_cell 1.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+#        },
+#        dep_kinds: [
+#            DepKindInfo {
+#                kind: Normal,
+#                cfg: None,
+#            },
+#        ],
+#    },
+#]
+#note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+#
+#Once this version has been shown to work the version of cargo-deny can be
+#downgraded in the harrison-ai/rust:1.75 image and this dockerfile removed.
+RUN cargo install -f --version 0.14.1 cargo-deny --no-default-features

--- a/scripts/Dockerfile-awslocal
+++ b/scripts/Dockerfile-awslocal
@@ -6,6 +6,15 @@ RUN apt-get update && \
     apt-get install --yes --quiet --no-install-recommends \
         ca-certificates \
         groff \
-        python-dev
+        python-dev \
+        curl \
+        wget \
+        unzip \
+        less
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm awscliv2.zip && \
+    rm -rf ./aws/
 
-RUN pip install awscli-local[ver1]
+RUN pip install awscli-local

--- a/scripts/run_example.sh
+++ b/scripts/run_example.sh
@@ -1,5 +1,7 @@
 set -e
 
+# Disable AWS CLI paging feature
+export AWS_PAGER=""
 # Choose the example to run
 export EXAMPLE=hello_lambda
 
@@ -20,7 +22,7 @@ docker compose up -d localstack
 sleep 5
 
 # Setup the queue
-export QUEUE_NAME=test-queue
+export QUEUE_NAME=example-test-queue
 $AWSLOCAL sqs create-queue --queue-name="$QUEUE_NAME" --attributes '{ "VisibilityTimeout": "240" }'
 QUEUE_URL=$($AWSLOCAL sqs list-queues | jq -r '.QueueUrls[0]')
 QUEUE_ARN=$($AWSLOCAL sqs get-queue-attributes --queue-url="$QUEUE_URL" --attribute-names QueueArn | jq -r '.Attributes.QueueArn')
@@ -34,7 +36,7 @@ cp target/x86_64-unknown-linux-musl/debug/examples/$EXAMPLE bootstrap && zip lam
 # Create a lambda function
 $AWSLOCAL lambda create-function \
    --function-name=$EXAMPLE \
-   --role=rn:aws:iam:local \
+   --role=arn:aws:iam::123456789012:role/example \
    --zip-file=fileb://lambda.zip \
    --environment "Variables={$ENV}" \
    --runtime=provided

--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -301,7 +301,7 @@ where
     // for future work). To work around this, we capture any errors during this phase
     // and pass them into the handler function itself, so that it can raise the error
     // when the function is invoked.
-    let init_result = (|| async {
+    let init_result = async {
         // Setup tracing
         tracing_subscriber::fmt()
             .with_env_filter(
@@ -322,7 +322,7 @@ where
         tracing::info!("Env: {:?}", env);
         tracing::info!("Context: {:?}", ctx);
         Ok::<_, anyhow::Error>(ctx)
-    })()
+    }
     .await;
 
     lambda_runtime::run(service_fn(|event: LambdaEvent<EventType>| async {

--- a/src/s3/async_put_object.rs
+++ b/src/s3/async_put_object.rs
@@ -1,13 +1,20 @@
+// Standard library imports
+use std::mem;
+use std::pin::Pin;
+
+// External crates
 use aws_sdk_s3::{
     operation::put_object::{PutObjectError, PutObjectOutput},
     types::ObjectCannedAcl,
 };
-use futures::io::{Error, ErrorKind};
-use futures::task::{Context, Poll};
-use futures::{ready, AsyncWrite, Future};
-use std::mem;
-use std::pin::Pin;
+use futures::{
+    io::{Error, ErrorKind},
+    ready,
+    task::{Context, Poll},
+    AsyncWrite, Future,
+};
 
+// Internal project imports
 use crate::s3::Client;
 use crate::types::SdkError;
 
@@ -162,7 +169,6 @@ mod test_async_put_object {
             .downcast_ref::<PutObjectError>()
             .unwrap();
 
-        assert!(matches!(e, PutObjectError::Unhandled(_)));
         assert_eq!(e.code(), Some("NoSuchBucket"));
     }
 

--- a/src/s3/mod.rs
+++ b/src/s3/mod.rs
@@ -230,7 +230,6 @@ mod test {
         types::{BucketLocationConstraint, CreateBucketConfiguration},
         Client,
     };
-    //use aws_smithy_http::SdkError;
     use rand::distributions::{Alphanumeric, DistString};
     use rand::Rng;
     use rand::SeedableRng;

--- a/src/s3/mod.rs
+++ b/src/s3/mod.rs
@@ -1,19 +1,28 @@
 //! A collection of wrappers around the [aws_sdk_s3](https://docs.rs/aws-sdk-s3/latest/aws_sdk_s3/) crate.
 
+// Standard library imports
+use std::pin::Pin;
+use std::{fmt::Debug, io::Error};
+
+// External crates
 use anyhow::Result;
 use aws_sdk_s3::{
     config::Builder,
     operation::{get_object::GetObjectError, list_objects_v2::ListObjectsV2Error},
+    primitives::ByteStream,
     types::Object,
 };
+use aws_smithy_async::future::pagination_stream::{PaginationStream, TryFlatMap};
 use aws_types::SdkConfig;
-use core::fmt::Debug;
-use futures::stream;
-use futures::stream::Stream;
-use futures::{AsyncBufRead, TryStreamExt};
+use bytes::Bytes;
+use futures::{
+    stream::Stream,
+    task::{Context, Poll},
+    AsyncBufRead, TryStreamExt,
+};
 
-use crate::localstack;
-use crate::types::SdkError;
+// Internal project imports
+use crate::{localstack, types::SdkError};
 
 /// Re-export of [aws_sdk_s3::client::Client](https://docs.rs/aws-sdk-s3/latest/aws_sdk_s3/client/struct.Client.html).
 ///
@@ -25,6 +34,70 @@ mod s3_object;
 pub use async_multipart_put_object::AsyncMultipartUpload;
 pub use async_put_object::AsyncPutObject;
 pub use s3_object::S3Object;
+
+/// `FuturesStreamCompatByteStream` is a compatibility layer struct designed to wrap
+/// `ByteStream` from the `aws_sdk_s3`. This wrapper enables the use of `ByteStream`
+/// with the `futures::Stream` trait, which is necessary for integration with libraries
+/// that rely on the futures crate, such as `cobalt-aws`.
+///
+/// # Why
+/// The `aws_sdk_s3` uses Tokio's async model and exposes streams (such as `ByteStream`)
+/// that are specific to Tokio's ecosystem. However, the `cobalt-aws` library operates
+/// on the futures crate's async model. `FuturesStreamCompatByteStream` bridges this gap,
+/// allowing `ByteStream` to be used where a `futures::Stream` is required, ensuring
+/// compatibility and interoperability between these two different async ecosystems.
+#[derive(Debug, Default)]
+struct FuturesStreamCompatByteStream(ByteStream);
+
+impl From<ByteStream> for FuturesStreamCompatByteStream {
+    fn from(value: ByteStream) -> Self {
+        FuturesStreamCompatByteStream(value)
+    }
+}
+
+impl Stream for FuturesStreamCompatByteStream {
+    type Item = Result<Bytes, Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.0)
+            .poll_next(cx)
+            .map_err(std::io::Error::other)
+    }
+}
+
+/// `FuturesPaginationStream` is a struct that wraps the `PaginationStream` from
+/// `aws_smithy_async::future::pagination_stream`, adapting it to implement the `Stream`
+/// trait from the `futures` crate.
+///
+/// # Why
+/// `PaginationStream` in `aws_smithy_async` is designed to be runtime-agnostic and
+/// does not natively implement the `futures::Stream` trait. `FuturesPaginationStream`
+/// provides this implementation, making `PaginationStream` compatible with the futures-based
+/// asynchronous model used in libraries like `cobalt-aws`.
+///
+/// This adaptation is essential in scenarios where `cobalt-aws`, which relies on the
+/// `futures` crate, needs to work with the AWS SDK's pagination streams. It bridges
+/// the gap between different async runtimes and libraries, ensuring smoother integration
+/// and functionality in Rust async applications that rely on the futures ecosystem.
+///
+struct FuturesPaginiationStream<I>(PaginationStream<I>);
+
+impl<I> From<PaginationStream<I>> for FuturesPaginiationStream<I> {
+    fn from(value: PaginationStream<I>) -> Self {
+        FuturesPaginiationStream(value)
+    }
+}
+
+impl<I> Stream for FuturesPaginiationStream<I> {
+    type Item = I;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        Pin::new(&mut self.0).poll_next(cx)
+    }
+}
 
 /// Create an S3 client with LocalStack support.
 ///
@@ -112,17 +185,8 @@ pub fn list_objects(
         .bucket(bucket)
         .set_prefix(prefix)
         .into_paginator();
-    req.send()
-        .map_ok(|list_objs| {
-            stream::iter(
-                list_objs
-                    .contents
-                    .unwrap_or_default() // An empty bucket comes back as None, rather than an empty vector
-                    .into_iter()
-                    .map(Ok),
-            )
-        })
-        .try_flatten()
+    let flatend_stream = TryFlatMap::new(req.send()).flat_map(|x| x.contents.unwrap_or_default());
+    FuturesPaginiationStream::from(flatend_stream)
 }
 
 /// Retrieve an object from S3 as an `AsyncBufRead`.
@@ -150,10 +214,9 @@ pub async fn get_object(
 ) -> Result<impl AsyncBufRead + Debug, SdkError<GetObjectError>> {
     let req = client.get_object().bucket(bucket).key(key);
     let resp = req.send().await?;
-    Ok(resp
-        .body
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
-        .into_async_read())
+    Ok::<_, SdkError<GetObjectError>>(
+        FuturesStreamCompatByteStream::from(resp.body).into_async_read(),
+    )
 }
 
 #[cfg(test)]
@@ -167,7 +230,7 @@ mod test {
         types::{BucketLocationConstraint, CreateBucketConfiguration},
         Client,
     };
-    use aws_smithy_http::result::SdkError;
+    //use aws_smithy_http::SdkError;
     use rand::distributions::{Alphanumeric, DistString};
     use rand::Rng;
     use rand::SeedableRng;
@@ -300,9 +363,9 @@ mod test_list_objects {
             results[0].key,
             Some("some-prefix/nested-prefix/nested.txt".into())
         );
-        assert_eq!(results[0].size, 12);
+        assert_eq!(results[0].size, Some(12));
         assert_eq!(results[1].key, Some("some-prefix/prefixed.txt".into()));
-        assert_eq!(results[1].size, 14);
+        assert_eq!(results[1].size, Some(14));
     }
 
     #[tokio::test]
@@ -317,9 +380,9 @@ mod test_list_objects {
             results[0].key,
             Some("some-prefix/nested-prefix/nested.txt".into())
         );
-        assert_eq!(results[0].size, 12);
+        assert_eq!(results[0].size, Some(12));
         assert_eq!(results[1].key, Some("some-prefix/prefixed.txt".into()));
-        assert_eq!(results[1].size, 14);
+        assert_eq!(results[1].size, Some(14));
     }
 
     #[tokio::test]
@@ -338,7 +401,7 @@ mod test_list_objects {
             results[0].key,
             Some("some-prefix/nested-prefix/nested.txt".into())
         );
-        assert_eq!(results[0].size, 12);
+        assert_eq!(results[0].size, Some(12));
     }
 
     #[tokio::test]
@@ -392,33 +455,36 @@ mod test_get_object {
     #[serial]
     async fn test_non_existant_bucket() {
         let client = localstack_test_client().await;
-        let e = get_object(&client, "non-existant-bucket", "my-object")
-            .await
-            .unwrap_err();
-        let e = e
-            .source()
-            .unwrap()
-            .downcast_ref::<GetObjectError>()
-            .unwrap();
+        match get_object(&client, "non-existant-bucket", "my-object").await {
+            Ok(_) => panic!("Expected an error, but got Ok"),
+            Err(e) => {
+                let e = e
+                    .source()
+                    .unwrap()
+                    .downcast_ref::<GetObjectError>()
+                    .unwrap();
 
-        assert!(matches!(e, GetObjectError::Unhandled(_)));
-        assert_eq!(e.code(), Some("NoSuchBucket"));
+                assert_eq!(e.code(), Some("NoSuchBucket"));
+            }
+        }
     }
 
     #[tokio::test]
     #[serial]
     async fn test_non_existant_key() {
         let client = localstack_test_client().await;
-        let e = get_object(&client, "test-bucket", "non-existing-object")
-            .await
-            .unwrap_err();
-        let e = e
-            .source()
-            .unwrap()
-            .downcast_ref::<GetObjectError>()
-            .unwrap();
+        match get_object(&client, "test-bucket", "non-existing-object").await {
+            Ok(_) => panic!("Expected an error, but got Ok"),
+            Err(e) => {
+                let e = e
+                    .source()
+                    .unwrap()
+                    .downcast_ref::<GetObjectError>()
+                    .unwrap();
 
-        assert!(matches!(e, GetObjectError::NoSuchKey(_)));
+                assert!(matches!(e, GetObjectError::NoSuchKey(_)));
+            }
+        }
     }
 
     #[tokio::test]

--- a/src/s3/s3_object.rs
+++ b/src/s3/s3_object.rs
@@ -1,5 +1,7 @@
+// Standard library imports
 use std::str::FromStr;
 
+// External crates
 use anyhow::{bail, Context, Error, Result};
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,5 @@
 use aws_sdk_s3::primitives::SdkBody;
-use http::Response;
+use aws_smithy_runtime_api::http::Response;
 
 /// Convenience wrapper to handle http response
-pub(crate) type SdkError<E> = aws_smithy_http::result::SdkError<E, Response<SdkBody>>;
+pub(crate) type SdkError<E> = aws_sdk_s3::error::SdkError<E, Response<SdkBody>>;


### PR DESCRIPTION
# 📢 For the Reviewer

In this PR, we're updating various AWS SDK dependencies for the `cobalt-aws` project to align with the latest versions and introducing support for LocalStack 3.0.2. Please provide feedback following the conventional comments guidebook to streamline the review process.

# 🚦 Depends on

No other PRs.

# 🛠️ What

This PR includes the following key changes:

1. **Dependency Updates**: 
    - `aws-sdk-athena`: Upgraded from `0.29` to `1.10.0`.
    - `aws-config`: Updated to `1.1.2` with the `behavior-version-latest` feature.
    - `aws-sdk-s3`: Upgraded from `0.29` to `1.12.0`.
    - `aws-sdk-sqs`: Upgraded from `0.29` to `1.10.0`.
    - `aws-types`: Upgraded from `0.56` to `1.1.2`.
    - `aws-smithy-async`: Added `1.1.2`.
    - `aws-smithy-runtime-api`: Added `1.1.2`.
    - `aws-smithy-http`: Removed.

2. **New Internal Structs**: 
    - **FuturesStreamCompatByteStream**: Implemented to create a Futures stream from a ByteStream to maintain API to return a `futures::AsyncBufRead` .
    - **FuturesPaginationStream**: Designed to create a stream from a PaginationStream, enhancing asynchronous operations.  AWS does not provide runtime Stream implementations for the PaginationStream, this provides a `futures` implementation.

3. **LocalStack Upgrade**: Upgraded to LocalStack 3.0.2, involving modifications in initializing LocalStack and ensuring its proper initialization.

# ❓ Why

The primary goals for this PR are:

- **Keeping Dependencies Updated**: Ensuring our project uses the latest versions of dependencies for enhanced security, performance, and access to new features.
- **Maintain Asynchronous Support**: By introducing `FuturesStreamCompatByteStream` and `FuturesPaginationStream`, we aim to maintain our asynchronous data operations.
- **Compatibility with LocalStack 3.0.2**: The upgrade is crucial for maintaining compatibility with the latest local AWS cloud stack, which is essential for testing and development purposes.

# 😟 Concerns

- **Integration Testing**: Given the significant dependency updates and new features, extensive integration testing is necessary to ensure compatibility and stability.
- **LocalStack Changes**: The LocalStack upgrade might introduce unforeseen challenges during local development and testing.

# 📝 Notes
During the process of passing the integration test, it was observed that the cargo-deny version 0.14.3 in the rust base image led to failures in executing cargo deny check. To resolve this, a docker file was introduced to revert to version 0.14.1, the earliest version that operates correctly. This temporary local modification was chosen to expedite the review and merging of this ticket. The plan is to propose a change for downgrading cargo-deny in the primary docker repository. The update will be applied to this ticket or a new one will be created in this repository to eliminate the rust-dev.dockerfile after the primary repository releases a new version. It's important to note that the issue with cargo-deny was exclusively found when running it inside docker.
