### PR TITLE
Update the cargo toml version to 0.13.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cobalt-aws"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["harrison.ai Data Engineering <dataengineering@harrison.ai>"]
 edition = "2021"
 description = "This library provides a collection of wrappers around the aws-sdk-rust and lambda_runtime packages."


### PR DESCRIPTION
## What

Upgrade the crate toml version.

## Why

In order to release 0.13.1 the cargo.toml must be updated.

## Depends on

None

* See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info.
