### PR TITLE
feat: Add feature flags to crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.4
+
+ - Added feature flags `"s3", "sqs", "athena", "lambda"`. By default, all features are enabled, so no breaking change.
+
 ## 0.13.3
 
  - aws-config: Upgraded from 1.1.6 to 1.3.0.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,17 +16,24 @@ include = [
     "licenses/licenses.html",
 ]
 
+[features]
+default = ["s3", "sqs", "athena", "lambda"]
+s3 = ["aws-smithy-async", "aws-sdk-s3"]
+sqs = ["aws-sdk-sqs"]
+athena = ["aws-sdk-athena"]
+lambda = ["aws_lambda_events"]
+
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
 aws-config = { version = "1.3.0", features = ["behavior-version-latest"] }
-aws-sdk-athena = "1.23.0"
-aws-sdk-s3 = "1.25.0"
-aws-sdk-sqs = "1.22.0"
-aws-smithy-async = "1.2.1"
+aws-sdk-athena = { version = "1.23.0", optional = true}
+aws-sdk-s3 = { version = "1.25.0", optional = true }
+aws-sdk-sqs = { version = "1.22.0", optional = true }
+aws-smithy-async = { version ="1.2.1", optional = true }
 aws-smithy-runtime-api = "1.5.0"
 aws-types = "1.2.0"
-aws_lambda_events = { version = "0.15", default-features = false, features = ["sqs"] }
+aws_lambda_events = { version = "0.15", default-features = false, features = ["sqs"], optional = true }
 bytes = "1.6.0"
 bytesize = "1.3"
 clap = { version = "4.5", features = ["derive", "env"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,11 +19,16 @@
 
 // Public modules
 
+#[cfg(feature = "athena")]
 pub mod athena;
 pub mod config;
+#[cfg(feature = "lambda")]
 pub mod lambda;
+#[cfg(feature = "s3")]
 pub mod s3;
+#[cfg(feature = "sqs")]
 pub mod sqs;
+#[cfg(feature = "s3")]
 pub mod types;
 // Internal shared modules
 mod localstack;


### PR DESCRIPTION
## What

This PR adds feature flags `"s3", "sqs", "athena", "lambda"` to the crate.

## Why

For use cases where we only want to interact with one particular service, we want to be able to only pull in those `aws-sdk-*` crates that are absolutely necessary. These feature flags give the user that ability, which will reduce build times and binary sizes.

