### PR TITLE
chore: release 0.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
 ## 0.13.4
 
  - Added feature flags `"s3", "sqs", "athena", "lambda"`. By default, all features are enabled, so no breaking change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cobalt-aws"
-version = "0.13.3"
+version = "0.13.4"
 authors = ["harrison.ai Data Engineering <dataengineering@harrison.ai>"]
 edition = "2021"
 description = "This library provides a collection of wrappers around the aws-sdk-rust and lambda_runtime packages."

--- a/licenses/licenses.html
+++ b/licenses/licenses.html
@@ -46,8 +46,8 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (188)</li>
-            <li><a href="#MIT">MIT License</a> (58)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (213)</li>
+            <li><a href="#MIT">MIT License</a> (60)</li>
             <li><a href="#ISC">ISC License</a> (4)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (2)</li>
             <li><a href="#OpenSSL">OpenSSL License</a> (1)</li>
@@ -60,21 +60,22 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/harrison-ai/cobalt-aws/ ">cobalt-aws 0.13.3</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-config 1.3.0</a></li>
+                    <li><a href=" https://github.com/harrison-ai/cobalt-aws/ ">cobalt-aws 0.13.4</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-config 1.5.1</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-credential-types 1.2.0</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-runtime 1.2.0</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-runtime 1.2.2</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-sigv4 1.2.1</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-async 1.2.1</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-checksums 0.60.7</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-checksums 0.60.9</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-eventstream 0.60.4</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http 0.60.8</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-json 0.60.7</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-query 0.60.7</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime-api 1.5.0</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime 1.4.0</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-types 1.1.8</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime-api 1.6.2</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime 1.5.5</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-types 1.1.10</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-xml 0.60.8</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-types 1.2.0</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-types 1.3.1</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -1288,7 +1289,7 @@
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-sigv4 1.2.1</a></li>
                     <li><a href=" https://github.com/hsivonen/encoding_rs ">encoding_rs 0.8.34</a></li>
-                    <li><a href=" https://github.com/RustCrypto/utils/tree/master/zeroize ">zeroize 1.7.0</a></li>
+                    <li><a href=" https://github.com/RustCrypto/utils/tree/master/zeroize ">zeroize 1.8.1</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -2116,7 +2117,7 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.7.32</a></li>
+                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.7.34</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -2329,6 +2330,8 @@
                     <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.5.2</a></li>
                     <li><a href=" https://github.com/clap-rs/clap/tree/master/clap_derive ">clap_derive 4.5.4</a></li>
                     <li><a href=" https://github.com/clap-rs/clap/tree/master/clap_lex ">clap_lex 0.7.0</a></li>
+                    <li><a href=" https://github.com/frozenlib/test-strategy ">test-strategy 0.3.1</a></li>
+                    <li><a href=" https://github.com/cameron1024/unarray ">unarray 0.1.4</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -2746,7 +2749,7 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-parse 0.2.3</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-parse 0.2.4</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -2955,18 +2958,20 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstream 0.6.13</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle ">anstyle-query 1.0.2</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.6</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstream 0.6.14</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle ">anstyle-query 1.1.0</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.7</a></li>
                     <li><a href=" https://github.com/hyunsik/bytesize/ ">bytesize 1.3.0</a></li>
                     <li><a href=" https://github.com/clap-rs/clap ">clap 4.5.4</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle ">colorchoice 1.0.0</a></li>
-                    <li><a href=" https://github.com/srijs/rust-crc32fast ">crc32fast 1.4.0</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle ">colorchoice 1.0.1</a></li>
+                    <li><a href=" https://github.com/srijs/rust-crc32fast ">crc32fast 1.4.2</a></li>
                     <li><a href=" https://github.com/sfackler/foreign-types ">foreign-types-shared 0.1.1</a></li>
                     <li><a href=" https://github.com/sfackler/foreign-types ">foreign-types 0.3.2</a></li>
                     <li><a href=" https://github.com/KokaKiwi/rust-hex ">hex 0.4.3</a></li>
-                    <li><a href=" https://github.com/sfackler/rust-native-tls ">native-tls 0.2.11</a></li>
+                    <li><a href=" https://github.com/polyfill-rs/is_terminal_polyfill ">is_terminal_polyfill 1.70.0</a></li>
+                    <li><a href=" https://github.com/sfackler/rust-native-tls ">native-tls 0.2.12</a></li>
                     <li><a href=" https://crates.io/crates/openssl-macros ">openssl-macros 0.1.1</a></li>
+                    <li><a href=" http://github.com/tailhook/quick-error ">quick-error 1.2.3</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3176,7 +3181,7 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/wvwwvwwv/scalable-concurrent-containers/ ">scc 2.1.0</a></li>
+                    <li><a href=" https://github.com/wvwwvwwv/scalable-concurrent-containers/ ">scc 2.1.1</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3374,12 +3379,12 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-athena 1.23.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-s3 1.25.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sqs 1.22.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sso 1.22.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-ssooidc 1.22.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sts 1.22.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-athena 1.30.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-s3 1.33.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sqs 1.29.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sso 1.29.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-ssooidc 1.30.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sts 1.29.0</a></li>
                 </ul>
                 <pre class="license-text">                                Apache License
                            Version 2.0, January 2004
@@ -3589,23 +3594,25 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.82</a></li>
+                    <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.86</a></li>
                     <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.80</a></li>
                     <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.11</a></li>
-                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.154</a></li>
-                    <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.81</a></li>
+                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.155</a></li>
+                    <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.85</a></li>
                     <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.36</a></li>
-                    <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.17</a></li>
-                    <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.22</a></li>
-                    <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.200</a></li>
-                    <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.200</a></li>
-                    <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.116</a></li>
+                    <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.18</a></li>
+                    <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.23</a></li>
+                    <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.203</a></li>
+                    <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.203</a></li>
+                    <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.117</a></li>
                     <li><a href=" https://github.com/dtolnay/path-to-error ">serde_path_to_error 0.1.16</a></li>
                     <li><a href=" https://github.com/nox/serde_urlencoded ">serde_urlencoded 0.7.1</a></li>
-                    <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.60</a></li>
+                    <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.66</a></li>
+                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 1.0.61</a></li>
+                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 1.0.61</a></li>
                     <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.12</a></li>
                     <li><a href=" https://github.com/alacritty/vte ">utf8parse 0.2.1</a></li>
-                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.7.32</a></li>
+                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.7.34</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5471,7 +5478,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.5.0</a></li>
+                    <li><a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.7.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5681,15 +5688,16 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/tkaitchuck/ahash ">ahash 0.8.11</a></li>
-                    <li><a href=" https://github.com/cuviper/autocfg ">autocfg 1.2.0</a></li>
+                    <li><a href=" https://github.com/smol-rs/atomic-waker ">atomic-waker 1.1.2</a></li>
+                    <li><a href=" https://github.com/cuviper/autocfg ">autocfg 1.3.0</a></li>
                     <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.21.7</a></li>
                     <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.22.1</a></li>
                     <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.5.0</a></li>
                     <li><a href=" https://github.com/vorner/bytes-utils ">bytes-utils 0.1.4</a></li>
-                    <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.0.96</a></li>
+                    <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.0.98</a></li>
                     <li><a href=" https://github.com/alexcrichton/cfg-if ">cfg-if 1.0.0</a></li>
                     <li><a href=" https://github.com/mcarton/rust-derivative ">derivative 2.2.0</a></li>
-                    <li><a href=" https://github.com/rayon-rs/either ">either 1.11.0</a></li>
+                    <li><a href=" https://github.com/rayon-rs/either ">either 1.12.0</a></li>
                     <li><a href=" https://github.com/cuviper/equivalent ">equivalent 1.0.1</a></li>
                     <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.1.0</a></li>
                     <li><a href=" https://github.com/servo/rust-fnv ">fnv 1.0.7</a></li>
@@ -5703,28 +5711,33 @@ limitations under the License.
                     <li><a href=" https://github.com/servo/rust-url/ ">idna 0.5.0</a></li>
                     <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.2.6</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static 1.4.0</a></li>
+                    <li><a href=" https://github.com/rust-lang/libm ">libm 0.2.8</a></li>
+                    <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.4.14</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.12</a></li>
                     <li><a href=" https://github.com/rust-lang/log ">log 0.4.21</a></li>
                     <li><a href=" https://github.com/hyperium/mime ">mime 0.3.17</a></li>
                     <li><a href=" https://github.com/rust-num/num-integer ">num-integer 0.1.46</a></li>
-                    <li><a href=" https://github.com/rust-num/num-traits ">num-traits 0.2.18</a></li>
+                    <li><a href=" https://github.com/rust-num/num-traits ">num-traits 0.2.19</a></li>
                     <li><a href=" https://github.com/seanmonstar/num_cpus ">num_cpus 1.16.0</a></li>
                     <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.19.0</a></li>
                     <li><a href=" https://github.com/alexcrichton/openssl-probe ">openssl-probe 0.1.5</a></li>
-                    <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot 0.12.2</a></li>
+                    <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot 0.12.3</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot_core 0.9.10</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding 2.3.1</a></li>
                     <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config 0.3.30</a></li>
+                    <li><a href=" https://github.com/proptest-rs/proptest ">proptest 1.4.0</a></li>
                     <li><a href=" https://github.com/rust-lang/regex/tree/master/regex-automata ">regex-automata 0.4.6</a></li>
                     <li><a href=" https://github.com/rust-lang/regex/tree/master/regex-lite ">regex-lite 0.1.5</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.6.29</a></li>
                     <li><a href=" https://github.com/rust-lang/regex/tree/master/regex-syntax ">regex-syntax 0.8.3</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex 1.10.4</a></li>
                     <li><a href=" https://github.com/Kimundi/rustc-version-rs ">rustc_version 0.4.0</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 0.38.34</a></li>
                     <li><a href=" https://github.com/ctz/rustls-native-certs ">rustls-native-certs 0.6.3</a></li>
                     <li><a href=" https://github.com/rustls/pemfile ">rustls-pemfile 1.0.4</a></li>
                     <li><a href=" https://github.com/rustls/pemfile ">rustls-pemfile 2.1.2</a></li>
                     <li><a href=" https://github.com/rustls/rustls ">rustls 0.21.12</a></li>
+                    <li><a href=" https://github.com/altsysrq/rusty-fork ">rusty-fork 0.3.0</a></li>
                     <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
                     <li><a href=" https://github.com/rustls/sct.rs ">sct 0.7.1</a></li>
                     <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with 3.8.1</a></li>
@@ -5733,12 +5746,16 @@ limitations under the License.
                     <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.13.2</a></li>
                     <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.5.7</a></li>
                     <li><a href=" https://github.com/dtolnay/syn ">syn 1.0.109</a></li>
+                    <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.10.1</a></li>
                     <li><a href=" https://github.com/Amanieu/thread_local-rs ">thread_local 1.1.8</a></li>
+                    <li><a href=" https://github.com/idanarye/rust-typed-builder ">typed-builder-macro 0.18.2</a></li>
+                    <li><a href=" https://github.com/idanarye/rust-typed-builder ">typed-builder 0.18.2</a></li>
                     <li><a href=" https://github.com/servo/unicode-bidi ">unicode-bidi 0.3.15</a></li>
                     <li><a href=" https://github.com/unicode-rs/unicode-normalization ">unicode-normalization 0.1.23</a></li>
                     <li><a href=" https://github.com/servo/rust-url ">url 2.5.0</a></li>
                     <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.8.0</a></li>
                     <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.4</a></li>
+                    <li><a href=" https://github.com/alexcrichton/wait-timeout ">wait-timeout 0.2.0</a></li>
                     <li><a href=" https://github.com/RazrFalcon/xmlparser ">xmlparser 0.13.6</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -6152,6 +6169,216 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/contain-rs/bit-set ">bit-set 0.5.3</a></li>
+                    <li><a href=" https://github.com/contain-rs/bit-vec ">bit-vec 0.6.3</a></li>
+                </ul>
+                <pre class="license-text">                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   &quot;control&quot; means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   &quot;Source&quot; form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   &quot;Object&quot; form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   &quot;Work&quot; shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   &quot;Contribution&quot; shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+   replaced with your own identifying information. (Don&#x27;t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same &quot;printed page&quot; as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 </pre>
             </li>
             <li class="license">
@@ -6765,8 +6992,9 @@ APPENDIX: How to apply the Apache License to your work.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.2.14</a></li>
+                    <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.2.15</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.3.1</a></li>
+                    <li><a href=" https://github.com/rust-random/rngs ">rand_xorshift 0.3.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -7393,6 +7621,38 @@ additional terms or conditions.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/proptest-rs/proptest ">proptest 1.4.0</a></li>
+                </ul>
+                <pre class="license-text">//-
+// Copyright 2017
+//
+// Licensed under the Apache License, Version 2.0 &lt;LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0&gt; or the MIT license
+// &lt;LICENSE-MIT or http://opensource.org/licenses/MIT&gt;, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/altsysrq/rusty-fork ">rusty-fork 0.3.0</a></li>
+                </ul>
+                <pre class="license-text">//-
+// Copyright 2018
+//
+// Licensed under the Apache License, Version 2.0 &lt;LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0&gt; or the MIT license
+// &lt;LICENSE-MIT or http://opensource.org/licenses/MIT&gt;, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/pyfisch/httpdate ">httpdate 1.0.3</a></li>
                 </ul>
                 <pre class="license-text">Apache License
@@ -7603,10 +7863,13 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/zowens/crc32c ">crc32c 0.6.5</a></li>
-                    <li><a href=" https://gitlab.com/kornelski/http-serde ">http-serde 2.1.0</a></li>
+                    <li><a href=" https://github.com/DanielKeep/rust-custom-derive/tree/custom_derive-master ">custom_derive 0.1.7</a></li>
+                    <li><a href=" https://gitlab.com/kornelski/http-serde ">http-serde 2.1.1</a></li>
                     <li><a href=" https://github.com/TedDriggs/ident_case ">ident_case 1.0.1</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-lambda-rust-runtime ">lambda_runtime 0.11.1</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-lambda-rust-runtime ">lambda_runtime_api_client 0.11.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-lambda-rust-runtime ">lambda_runtime 0.11.2</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-lambda-rust-runtime ">lambda_runtime_api_client 0.11.1</a></li>
+                    <li><a href=" https://github.com/frozenlib/structmeta ">structmeta-derive 0.2.0</a></li>
+                    <li><a href=" https://github.com/frozenlib/structmeta ">structmeta 0.2.0</a></li>
                 </ul>
                 <pre class="license-text">Apache License
 Version 2.0, January 2004
@@ -7941,7 +8204,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/hyper ">hyper 0.14.28</a></li>
+                    <li><a href=" https://github.com/hyperium/hyper ">hyper 0.14.29</a></li>
                     <li><a href=" https://github.com/hyperium/hyper ">hyper 1.3.1</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014-2021 Sean McArthur
@@ -7963,6 +8226,39 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/DanielKeep/rust-conv ">conv 0.3.3</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2015 Daniel Keep
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the &quot;Software&quot;), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
 </pre>
             </li>
             <li class="license">
@@ -7998,7 +8294,7 @@ SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/hyperium/h2 ">h2 0.3.26</a></li>
-                    <li><a href=" https://github.com/hyperium/h2 ">h2 0.4.4</a></li>
+                    <li><a href=" https://github.com/hyperium/h2 ">h2 0.4.5</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2017 h2 authors
 
@@ -8402,7 +8698,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/hyper-util ">hyper-util 0.1.3</a></li>
+                    <li><a href=" https://github.com/hyperium/hyper-util ">hyper-util 0.1.5</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2023 Sean McArthur
 
@@ -8431,8 +8727,7 @@ THE SOFTWARE.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/tokio-rs/tokio ">tokio-stream 0.1.15</a></li>
                     <li><a href=" https://github.com/tokio-rs/tokio ">tokio-test 0.4.4</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.10</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.37.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.11</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2023 Tokio Contributors
 
@@ -8459,61 +8754,6 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.2.0</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2023 Tokio Contributors
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the &quot;Software&quot;), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-
-The MIT License (MIT)
-
-Copyright (c) 2019 Yoshua Wuyts
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 </pre>
             </li>
             <li class="license">
@@ -8548,9 +8788,9 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/TedDriggs/darling ">darling 0.20.8</a></li>
-                    <li><a href=" https://github.com/TedDriggs/darling ">darling_core 0.20.8</a></li>
-                    <li><a href=" https://github.com/TedDriggs/darling ">darling_macro 0.20.8</a></li>
+                    <li><a href=" https://github.com/TedDriggs/darling ">darling 0.20.9</a></li>
+                    <li><a href=" https://github.com/TedDriggs/darling ">darling_core 0.20.9</a></li>
+                    <li><a href=" https://github.com/TedDriggs/darling ">darling_macro 0.20.9</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -8579,7 +8819,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/awslabs/aws-lambda-rust-runtime ">aws_lambda_events 0.15.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-lambda-rust-runtime ">aws_lambda_events 0.15.1</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -8639,6 +8879,36 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.3.0</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2019 Yoshua Wuyts
+Copyright (c) Tokio Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/Nugine/outref ">outref 0.5.1</a></li>
                 </ul>
                 <pre class="license-text">MIT License
@@ -8668,6 +8938,7 @@ SOFTWARE.</pre>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/Nugine/simd ">base64-simd 0.8.0</a></li>
+                    <li><a href=" https://github.com/rutrum/convert-case ">convert_case 0.4.0</a></li>
                     <li><a href=" https://github.com/danielhenrymantilla/rust-function_name ">function_name-proc-macro 0.3.0</a></li>
                     <li><a href=" https://github.com/hyperium/http-body ">http-body-util 0.1.1</a></li>
                     <li><a href=" https://github.com/hyperium/http-body ">http-body 1.0.0</a></li>
@@ -8682,6 +8953,35 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.38.0</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) Tokio Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 </pre>
             </li>
             <li class="license">
@@ -8833,7 +9133,6 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/dguo/strsim-rs ">strsim 0.10.0</a></li>
                     <li><a href=" https://github.com/rapidfuzz/strsim-rs ">strsim 0.11.1</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
@@ -8841,6 +9140,35 @@ THE SOFTWARE.
 Copyright (c) 2015 Danny Guo
 Copyright (c) 2016 Titus Wormer &lt;tituswormer@gmail.com&gt;
 Copyright (c) 2018 Akash Kurdekar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/JelteF/derive_more ">derive_more 0.99.17</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2016 Jelte Fennema
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal


### PR DESCRIPTION
# Pull Request for `cobalt-aws` Release 0.13.4

## ✨ What

What changes have been made within this PR?
- This PR creates the release 0.13.4 for Cobalt-AWS.
- The release includes the following changes as per the change log:
  - Added feature flags `"s3", "sqs", "athena", "lambda"`. By default, all features are enabled, so no breaking change.
  - Added MultipartCopy to allow copy of files larger than 5GB.

## 💡 Why

Why are we submitting this PR?
- To officially release version 0.13.4 of `cobalt-aws`.
- To make the new features and improvements available to users.

## 🔗 Depends on

Are there any other PRs that need to be merged first?
- No dependencies on other PRs.

## ⚠️ Concerns

- No specific concerns at this time.

## 📝 Notes

- This release introduces property testing to help ensure more robust code.

* See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info.
