### PR TITLE
chore(deps): Update rust crate derive_more to v1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ bytesize = "1.3"
 clap = { version = "4.5", features = ["derive", "env"] }
 conv = "0.3.3"
 derivative = "2.2"
-derive_more = "0.99.17"
+derive_more = { version = "1.0", features = ["as_ref", "display", "from", "into"] }
 either = "1.12.0"
 futures = "0.3"
 http = "1.1"

--- a/licenses/licenses.html
+++ b/licenses/licenses.html
@@ -46,11 +46,10 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (49)</li>
-            <li><a href="#MIT">MIT License</a> (37)</li>
-            <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (3)</li>
-            <li><a href="#ISC">ISC License</a> (2)</li>
-            <li><a href="#NOASSERTION">NOASSERTION</a> (1)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (266)</li>
+            <li><a href="#MIT">MIT License</a> (66)</li>
+            <li><a href="#ISC">ISC License</a> (4)</li>
+            <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (2)</li>
             <li><a href="#OpenSSL">OpenSSL License</a> (1)</li>
             <li><a href="#Unicode-DFS-2016">Unicode License Agreement - Data Files and Software (2016)</a> (1)</li>
         </ul>
@@ -62,20 +61,21 @@
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/harrison-ai/cobalt-aws/ ">cobalt-aws 0.13.5</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-config 1.5.1</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-config 1.5.5</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-credential-types 1.2.0</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-runtime 1.3.0</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-runtime 1.4.0</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-sigv4 1.2.3</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-async 1.2.1</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-checksums 0.60.10</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-checksums 0.60.12</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-eventstream 0.60.4</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http 0.60.8</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http 0.60.9</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-json 0.60.7</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-query 0.60.7</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime-api 1.7.0</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime 1.5.5</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-types 1.2.0</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime-api 1.7.2</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime 1.6.3</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-types 1.2.2</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-xml 0.60.8</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-types 1.3.1</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-types 1.3.3</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -1078,7 +1078,6 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/time-rs/time ">time-macros 0.2.18</a></li>
                     <li><a href=" https://github.com/time-rs/time ">time 0.3.36</a></li>
                 </ul>
                 <pre class="license-text">
@@ -1289,8 +1288,9 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-sigv4 1.2.2</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-sigv4 1.2.3</a></li>
                     <li><a href=" https://github.com/hsivonen/encoding_rs ">encoding_rs 0.8.34</a></li>
+                    <li><a href=" https://github.com/Lokathor/tinyvec ">tinyvec 1.8.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils/tree/master/zeroize ">zeroize 1.8.1</a></li>
                 </ul>
                 <pre class="license-text">
@@ -1501,217 +1501,7 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/Lokathor/tinyvec ">tinyvec 1.6.0</a></li>
-                </ul>
-                <pre class="license-text">
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      &quot;control&quot; means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      &quot;Source&quot; form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      &quot;Object&quot; form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      &quot;Work&quot; shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      &quot;Contribution&quot; shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-      replaced with your own identifying information. (Don&#x27;t include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same &quot;printed page&quot; as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/wvwwvwwv/scalable-delayed-dealloc/ ">sdd 0.2.0</a></li>
+                    <li><a href=" https://github.com/wvwwvwwv/scalable-delayed-dealloc/ ">sdd 3.0.2</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, April 2004
@@ -1909,26 +1699,26 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-core 0.52.0</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.48.0</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.52.0</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.59.0</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.48.5</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.52.5</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.52.6</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.48.5</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.52.5</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.52.6</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_msvc 0.48.5</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_msvc 0.52.5</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_msvc 0.52.6</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnu 0.48.5</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnu 0.52.5</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnullvm 0.52.5</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnu 0.52.6</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnullvm 0.52.6</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_msvc 0.48.5</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_msvc 0.52.5</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_msvc 0.52.6</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnu 0.48.5</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnu 0.52.5</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnu 0.52.6</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnullvm 0.48.5</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnullvm 0.52.5</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnullvm 0.52.6</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_msvc 0.48.5</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_msvc 0.52.5</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_msvc 0.52.6</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -2347,8 +2137,8 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.7.34</a></li>
-                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.7.34</a></li>
+                    <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.7.35</a></li>
+                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.7.35</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -2558,10 +2348,10 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.5.7</a></li>
-                    <li><a href=" https://github.com/clap-rs/clap ">clap_derive 4.5.5</a></li>
-                    <li><a href=" https://github.com/clap-rs/clap ">clap_lex 0.7.1</a></li>
-                    <li><a href=" https://github.com/frozenlib/test-strategy ">test-strategy 0.3.1</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.5.15</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap_derive 4.5.13</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap_lex 0.7.2</a></li>
+                    <li><a href=" https://github.com/frozenlib/test-strategy ">test-strategy 0.4.0</a></li>
                     <li><a href=" https://github.com/cameron1024/unarray ">unarray 0.1.4</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
@@ -2980,7 +2770,7 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-parse 0.2.4</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-parse 0.2.5</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi 0.3.9</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
@@ -3190,18 +2980,18 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstream 0.6.14</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle ">anstyle-query 1.1.0</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-wincon 3.0.3</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.7</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstream 0.6.15</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle ">anstyle-query 1.1.1</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-wincon 3.0.4</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.8</a></li>
                     <li><a href=" https://github.com/hyunsik/bytesize/ ">bytesize 1.3.0</a></li>
-                    <li><a href=" https://github.com/clap-rs/clap ">clap 4.5.7</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle ">colorchoice 1.0.1</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap 4.5.16</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle ">colorchoice 1.0.2</a></li>
                     <li><a href=" https://github.com/srijs/rust-crc32fast ">crc32fast 1.4.2</a></li>
                     <li><a href=" https://github.com/sfackler/foreign-types ">foreign-types-shared 0.1.1</a></li>
                     <li><a href=" https://github.com/sfackler/foreign-types ">foreign-types 0.3.2</a></li>
                     <li><a href=" https://github.com/KokaKiwi/rust-hex ">hex 0.4.3</a></li>
-                    <li><a href=" https://github.com/polyfill-rs/is_terminal_polyfill ">is_terminal_polyfill 1.70.0</a></li>
+                    <li><a href=" https://github.com/polyfill-rs/is_terminal_polyfill ">is_terminal_polyfill 1.70.1</a></li>
                     <li><a href=" https://github.com/sfackler/rust-native-tls ">native-tls 0.2.12</a></li>
                     <li><a href=" https://crates.io/crates/openssl-macros ">openssl-macros 0.1.1</a></li>
                     <li><a href=" http://github.com/tailhook/quick-error ">quick-error 1.2.3</a></li>
@@ -3414,7 +3204,7 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/wvwwvwwv/scalable-concurrent-containers/ ">scc 2.1.1</a></li>
+                    <li><a href=" https://github.com/wvwwvwwv/scalable-concurrent-containers/ ">scc 2.1.16</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3612,221 +3402,12 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/RumovZ/android-tzdata ">android-tzdata 0.1.1</a></li>
-                </ul>
-                <pre class="license-text">                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1.  Definitions.
-
-    &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-    and distribution as defined by Sections 1 through 9 of this document.
-
-    &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-    the copyright owner that is granting the License.
-
-    &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-    other entities that control, are controlled by, or are under common
-    control with that entity. For the purposes of this definition,
-    &quot;control&quot; means (i) the power, direct or indirect, to cause the
-    direction or management of such entity, whether by contract or
-    otherwise, or (ii) ownership of fifty percent (50%) or more of the
-    outstanding shares, or (iii) beneficial ownership of such entity.
-
-    &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-    exercising permissions granted by this License.
-
-    &quot;Source&quot; form shall mean the preferred form for making modifications,
-    including but not limited to software source code, documentation
-    source, and configuration files.
-
-    &quot;Object&quot; form shall mean any form resulting from mechanical
-    transformation or translation of a Source form, including but
-    not limited to compiled object code, generated documentation,
-    and conversions to other media types.
-
-    &quot;Work&quot; shall mean the work of authorship, whether in Source or
-    Object form, made available under the License, as indicated by a
-    copyright notice that is included in or attached to the work
-    (an example is provided in the Appendix below).
-
-    &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-    form, that is based on (or derived from) the Work and for which the
-    editorial revisions, annotations, elaborations, or other modifications
-    represent, as a whole, an original work of authorship. For the purposes
-    of this License, Derivative Works shall not include works that remain
-    separable from, or merely link (or bind by name) to the interfaces of,
-    the Work and Derivative Works thereof.
-
-    &quot;Contribution&quot; shall mean any work of authorship, including
-    the original version of the Work and any modifications or additions
-    to that Work or Derivative Works thereof, that is intentionally
-    submitted to Licensor for inclusion in the Work by the copyright owner
-    or by an individual or Legal Entity authorized to submit on behalf of
-    the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-    means any form of electronic, verbal, or written communication sent
-    to the Licensor or its representatives, including but not limited to
-    communication on electronic mailing lists, source code control systems,
-    and issue tracking systems that are managed by, or on behalf of, the
-    Licensor for the purpose of discussing and improving the Work, but
-    excluding communication that is conspicuously marked or otherwise
-    designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-    &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-    on behalf of whom a Contribution has been received by Licensor and
-    subsequently incorporated within the Work.
-
-2.  Grant of Copyright License. Subject to the terms and conditions of
-    this License, each Contributor hereby grants to You a perpetual,
-    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-    copyright license to reproduce, prepare Derivative Works of,
-    publicly display, publicly perform, sublicense, and distribute the
-    Work and such Derivative Works in Source or Object form.
-
-3.  Grant of Patent License. Subject to the terms and conditions of
-    this License, each Contributor hereby grants to You a perpetual,
-    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-    (except as stated in this section) patent license to make, have made,
-    use, offer to sell, sell, import, and otherwise transfer the Work,
-    where such license applies only to those patent claims licensable
-    by such Contributor that are necessarily infringed by their
-    Contribution(s) alone or by combination of their Contribution(s)
-    with the Work to which such Contribution(s) was submitted. If You
-    institute patent litigation against any entity (including a
-    cross-claim or counterclaim in a lawsuit) alleging that the Work
-    or a Contribution incorporated within the Work constitutes direct
-    or contributory patent infringement, then any patent licenses
-    granted to You under this License for that Work shall terminate
-    as of the date such litigation is filed.
-
-4.  Redistribution. You may reproduce and distribute copies of the
-    Work or Derivative Works thereof in any medium, with or without
-    modifications, and in Source or Object form, provided that You
-    meet the following conditions:
-
-    (a) You must give any other recipients of the Work or
-    Derivative Works a copy of this License; and
-
-    (b) You must cause any modified files to carry prominent notices
-    stating that You changed the files; and
-
-    (c) You must retain, in the Source form of any Derivative Works
-    that You distribute, all copyright, patent, trademark, and
-    attribution notices from the Source form of the Work,
-    excluding those notices that do not pertain to any part of
-    the Derivative Works; and
-
-    (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-    distribution, then any Derivative Works that You distribute must
-    include a readable copy of the attribution notices contained
-    within such NOTICE file, excluding those notices that do not
-    pertain to any part of the Derivative Works, in at least one
-    of the following places: within a NOTICE text file distributed
-    as part of the Derivative Works; within the Source form or
-    documentation, if provided along with the Derivative Works; or,
-    within a display generated by the Derivative Works, if and
-    wherever such third-party notices normally appear. The contents
-    of the NOTICE file are for informational purposes only and
-    do not modify the License. You may add Your own attribution
-    notices within Derivative Works that You distribute, alongside
-    or as an addendum to the NOTICE text from the Work, provided
-    that such additional attribution notices cannot be construed
-    as modifying the License.
-
-    You may add Your own copyright statement to Your modifications and
-    may provide additional or different license terms and conditions
-    for use, reproduction, or distribution of Your modifications, or
-    for any such Derivative Works as a whole, provided Your use,
-    reproduction, and distribution of the Work otherwise complies with
-    the conditions stated in this License.
-
-5.  Submission of Contributions. Unless You explicitly state otherwise,
-    any Contribution intentionally submitted for inclusion in the Work
-    by You to the Licensor shall be under the terms and conditions of
-    this License, without any additional terms or conditions.
-    Notwithstanding the above, nothing herein shall supersede or modify
-    the terms of any separate license agreement you may have executed
-    with Licensor regarding such Contributions.
-
-6.  Trademarks. This License does not grant permission to use the trade
-    names, trademarks, service marks, or product names of the Licensor,
-    except as required for reasonable and customary use in describing the
-    origin of the Work and reproducing the content of the NOTICE file.
-
-7.  Disclaimer of Warranty. Unless required by applicable law or
-    agreed to in writing, Licensor provides the Work (and each
-    Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    implied, including, without limitation, any warranties or conditions
-    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-    PARTICULAR PURPOSE. You are solely responsible for determining the
-    appropriateness of using or redistributing the Work and assume any
-    risks associated with Your exercise of permissions under this License.
-
-8.  Limitation of Liability. In no event and under no legal theory,
-    whether in tort (including negligence), contract, or otherwise,
-    unless required by applicable law (such as deliberate and grossly
-    negligent acts) or agreed to in writing, shall any Contributor be
-    liable to You for damages, including any direct, indirect, special,
-    incidental, or consequential damages of any character arising as a
-    result of this License or out of the use or inability to use the
-    Work (including but not limited to damages for loss of goodwill,
-    work stoppage, computer failure or malfunction, or any and all
-    other commercial damages or losses), even if such Contributor
-    has been advised of the possibility of such damages.
-
-9.  Accepting Warranty or Additional Liability. While redistributing
-    the Work or Derivative Works thereof, You may choose to offer,
-    and charge a fee for, acceptance of support, warranty, indemnity,
-    or other liability obligations and/or rights consistent with this
-    License. However, in accepting such obligations, You may act only
-    on Your own behalf and on Your sole responsibility, not on behalf
-    of any other Contributor, and only if You agree to indemnify,
-    defend, and hold each Contributor harmless for any liability
-    incurred by, or claims asserted against, such Contributor by reason
-    of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-      replaced with your own identifying information. (Don&#x27;t include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same &quot;printed page&quot; as the copyright notice for easier
-      identification within third-party archives.
-
-Copyright [yyyy] [name of copyright owner]
-
-Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-athena 1.30.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-s3 1.34.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sqs 1.29.1</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sso 1.29.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-ssooidc 1.30.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sts 1.29.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-athena 1.41.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-s3 1.44.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sqs 1.38.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sso 1.39.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-ssooidc 1.40.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sts 1.39.0</a></li>
                 </ul>
                 <pre class="license-text">                                Apache License
                            Version 2.0, January 2004
@@ -4037,23 +3618,24 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.86</a></li>
-                    <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.80</a></li>
+                    <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.81</a></li>
                     <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.11</a></li>
-                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.155</a></li>
-                    <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.85</a></li>
+                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.156</a></li>
+                    <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.86</a></li>
                     <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.36</a></li>
                     <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.18</a></li>
                     <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.23</a></li>
-                    <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.203</a></li>
-                    <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.203</a></li>
-                    <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.117</a></li>
+                    <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.208</a></li>
+                    <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.208</a></li>
+                    <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.125</a></li>
                     <li><a href=" https://github.com/dtolnay/path-to-error ">serde_path_to_error 0.1.16</a></li>
                     <li><a href=" https://github.com/nox/serde_urlencoded ">serde_urlencoded 0.7.1</a></li>
-                    <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.66</a></li>
-                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 1.0.61</a></li>
-                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 1.0.61</a></li>
+                    <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.74</a></li>
+                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 1.0.63</a></li>
+                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 1.0.63</a></li>
                     <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.12</a></li>
                     <li><a href=" https://github.com/alacritty/vte ">utf8parse 0.2.2</a></li>
+                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.7.35</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5083,7 +4665,6 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/rustls/tokio-rustls ">tokio-rustls 0.24.1</a></li>
-                    <li><a href=" https://github.com/rustls/tokio-rustls ">tokio-rustls 0.26.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5711,7 +5292,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/cryptocorrosion/cryptocorrosion ">ppv-lite86 0.2.17</a></li>
+                    <li><a href=" https://github.com/cryptocorrosion/cryptocorrosion ">ppv-lite86 0.2.20</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5920,217 +5501,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/strawlab/iana-time-zone ">iana-time-zone-haiku 0.1.2</a></li>
-                    <li><a href=" https://github.com/strawlab/iana-time-zone ">iana-time-zone 0.1.60</a></li>
-                </ul>
-                <pre class="license-text">                              Apache License
-                        Version 2.0, January 2004
-                     http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-   and distribution as defined by Sections 1 through 9 of this document.
-
-   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-   the copyright owner that is granting the License.
-
-   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-   other entities that control, are controlled by, or are under common
-   control with that entity. For the purposes of this definition,
-   &quot;control&quot; means (i) the power, direct or indirect, to cause the
-   direction or management of such entity, whether by contract or
-   otherwise, or (ii) ownership of fifty percent (50%) or more of the
-   outstanding shares, or (iii) beneficial ownership of such entity.
-
-   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-   exercising permissions granted by this License.
-
-   &quot;Source&quot; form shall mean the preferred form for making modifications,
-   including but not limited to software source code, documentation
-   source, and configuration files.
-
-   &quot;Object&quot; form shall mean any form resulting from mechanical
-   transformation or translation of a Source form, including but
-   not limited to compiled object code, generated documentation,
-   and conversions to other media types.
-
-   &quot;Work&quot; shall mean the work of authorship, whether in Source or
-   Object form, made available under the License, as indicated by a
-   copyright notice that is included in or attached to the work
-   (an example is provided in the Appendix below).
-
-   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-   form, that is based on (or derived from) the Work and for which the
-   editorial revisions, annotations, elaborations, or other modifications
-   represent, as a whole, an original work of authorship. For the purposes
-   of this License, Derivative Works shall not include works that remain
-   separable from, or merely link (or bind by name) to the interfaces of,
-   the Work and Derivative Works thereof.
-
-   &quot;Contribution&quot; shall mean any work of authorship, including
-   the original version of the Work and any modifications or additions
-   to that Work or Derivative Works thereof, that is intentionally
-   submitted to Licensor for inclusion in the Work by the copyright owner
-   or by an individual or Legal Entity authorized to submit on behalf of
-   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-   means any form of electronic, verbal, or written communication sent
-   to the Licensor or its representatives, including but not limited to
-   communication on electronic mailing lists, source code control systems,
-   and issue tracking systems that are managed by, or on behalf of, the
-   Licensor for the purpose of discussing and improving the Work, but
-   excluding communication that is conspicuously marked or otherwise
-   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-   on behalf of whom a Contribution has been received by Licensor and
-   subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   copyright license to reproduce, prepare Derivative Works of,
-   publicly display, publicly perform, sublicense, and distribute the
-   Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   (except as stated in this section) patent license to make, have made,
-   use, offer to sell, sell, import, and otherwise transfer the Work,
-   where such license applies only to those patent claims licensable
-   by such Contributor that are necessarily infringed by their
-   Contribution(s) alone or by combination of their Contribution(s)
-   with the Work to which such Contribution(s) was submitted. If You
-   institute patent litigation against any entity (including a
-   cross-claim or counterclaim in a lawsuit) alleging that the Work
-   or a Contribution incorporated within the Work constitutes direct
-   or contributory patent infringement, then any patent licenses
-   granted to You under this License for that Work shall terminate
-   as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-   Work or Derivative Works thereof in any medium, with or without
-   modifications, and in Source or Object form, provided that You
-   meet the following conditions:
-
-   (a) You must give any other recipients of the Work or
-       Derivative Works a copy of this License; and
-
-   (b) You must cause any modified files to carry prominent notices
-       stating that You changed the files; and
-
-   (c) You must retain, in the Source form of any Derivative Works
-       that You distribute, all copyright, patent, trademark, and
-       attribution notices from the Source form of the Work,
-       excluding those notices that do not pertain to any part of
-       the Derivative Works; and
-
-   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-       distribution, then any Derivative Works that You distribute must
-       include a readable copy of the attribution notices contained
-       within such NOTICE file, excluding those notices that do not
-       pertain to any part of the Derivative Works, in at least one
-       of the following places: within a NOTICE text file distributed
-       as part of the Derivative Works; within the Source form or
-       documentation, if provided along with the Derivative Works; or,
-       within a display generated by the Derivative Works, if and
-       wherever such third-party notices normally appear. The contents
-       of the NOTICE file are for informational purposes only and
-       do not modify the License. You may add Your own attribution
-       notices within Derivative Works that You distribute, alongside
-       or as an addendum to the NOTICE text from the Work, provided
-       that such additional attribution notices cannot be construed
-       as modifying the License.
-
-   You may add Your own copyright statement to Your modifications and
-   may provide additional or different license terms and conditions
-   for use, reproduction, or distribution of Your modifications, or
-   for any such Derivative Works as a whole, provided Your use,
-   reproduction, and distribution of the Work otherwise complies with
-   the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-   any Contribution intentionally submitted for inclusion in the Work
-   by You to the Licensor shall be under the terms and conditions of
-   this License, without any additional terms or conditions.
-   Notwithstanding the above, nothing herein shall supersede or modify
-   the terms of any separate license agreement you may have executed
-   with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade
-   names, trademarks, service marks, or product names of the Licensor,
-   except as required for reasonable and customary use in describing the
-   origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-   agreed to in writing, Licensor provides the Work (and each
-   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied, including, without limitation, any warranties or conditions
-   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-   PARTICULAR PURPOSE. You are solely responsible for determining the
-   appropriateness of using or redistributing the Work and assume any
-   risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-   whether in tort (including negligence), contract, or otherwise,
-   unless required by applicable law (such as deliberate and grossly
-   negligent acts) or agreed to in writing, shall any Contributor be
-   liable to You for damages, including any direct, indirect, special,
-   incidental, or consequential damages of any character arising as a
-   result of this License or out of the use or inability to use the
-   Work (including but not limited to damages for loss of goodwill,
-   work stoppage, computer failure or malfunction, or any and all
-   other commercial damages or losses), even if such Contributor
-   has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-   the Work or Derivative Works thereof, You may choose to offer,
-   and charge a fee for, acceptance of support, warranty, indemnity,
-   or other liability obligations and/or rights consistent with this
-   License. However, in accepting such obligations, You may act only
-   on Your own behalf and on Your sole responsibility, not on behalf
-   of any other Contributor, and only if You agree to indemnify,
-   defend, and hold each Contributor harmless for any liability
-   incurred by, or claims asserted against, such Contributor by reason
-   of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-   replaced with your own identifying information. (Don&#x27;t include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same &quot;printed page&quot; as the copyright notice for easier
-   identification within third-party archives.
-
-Copyright 2020 Andrew Straw
-
-Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.7.0</a></li>
+                    <li><a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.8.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -6347,15 +5718,15 @@ limitations under the License.
                     <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.21.7</a></li>
                     <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.22.1</a></li>
                     <li><a href=" https://github.com/bitflags/bitflags ">bitflags 1.3.2</a></li>
-                    <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.5.0</a></li>
+                    <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.6.0</a></li>
                     <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.16.0</a></li>
                     <li><a href=" https://github.com/vorner/bytes-utils ">bytes-utils 0.1.4</a></li>
-                    <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.0.99</a></li>
+                    <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.1.13</a></li>
                     <li><a href=" https://github.com/alexcrichton/cfg-if ">cfg-if 1.0.0</a></li>
-                    <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation-sys 0.8.6</a></li>
+                    <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation-sys 0.8.7</a></li>
                     <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation 0.9.4</a></li>
                     <li><a href=" https://github.com/mcarton/rust-derivative ">derivative 2.2.0</a></li>
-                    <li><a href=" https://github.com/rayon-rs/either ">either 1.12.0</a></li>
+                    <li><a href=" https://github.com/rayon-rs/either ">either 1.13.0</a></li>
                     <li><a href=" https://github.com/cuviper/equivalent ">equivalent 1.0.1</a></li>
                     <li><a href=" https://github.com/lambda-fairy/rust-errno ">errno 0.3.9</a></li>
                     <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.1.0</a></li>
@@ -6363,77 +5734,73 @@ limitations under the License.
                     <li><a href=" https://github.com/servo/rust-url ">form_urlencoded 1.2.1</a></li>
                     <li><a href=" https://github.com/gimli-rs/gimli ">gimli 0.29.0</a></li>
                     <li><a href=" https://github.com/zkcrypto/group ">group 0.12.1</a></li>
-                    <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.12.3</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.14.5</a></li>
                     <li><a href=" https://github.com/withoutboats/heck ">heck 0.5.0</a></li>
                     <li><a href=" https://github.com/hermit-os/hermit-rs ">hermit-abi 0.3.9</a></li>
                     <li><a href=" https://github.com/seanmonstar/httparse ">httparse 1.9.4</a></li>
                     <li><a href=" https://github.com/rustls/hyper-rustls ">hyper-rustls 0.24.2</a></li>
-                    <li><a href=" https://github.com/rustls/hyper-rustls ">hyper-rustls 0.27.2</a></li>
                     <li><a href=" https://github.com/hyperium/hyper-tls ">hyper-tls 0.6.0</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">idna 0.5.0</a></li>
-                    <li><a href=" https://github.com/bluss/indexmap ">indexmap 1.9.3</a></li>
-                    <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.2.6</a></li>
-                    <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.69</a></li>
-                    <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static 1.4.0</a></li>
+                    <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.4.0</a></li>
+                    <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.70</a></li>
+                    <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static 1.5.0</a></li>
                     <li><a href=" https://github.com/rust-lang/libm ">libm 0.2.8</a></li>
                     <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.4.14</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.12</a></li>
-                    <li><a href=" https://github.com/rust-lang/log ">log 0.4.21</a></li>
+                    <li><a href=" https://github.com/rust-lang/log ">log 0.4.22</a></li>
                     <li><a href=" https://github.com/hyperium/mime ">mime 0.3.17</a></li>
                     <li><a href=" https://github.com/rust-num/num-integer ">num-integer 0.1.46</a></li>
                     <li><a href=" https://github.com/rust-num/num-traits ">num-traits 0.2.19</a></li>
-                    <li><a href=" https://github.com/seanmonstar/num_cpus ">num_cpus 1.16.0</a></li>
-                    <li><a href=" https://github.com/gimli-rs/object ">object 0.36.0</a></li>
+                    <li><a href=" https://github.com/gimli-rs/object ">object 0.36.3</a></li>
                     <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.19.0</a></li>
                     <li><a href=" https://github.com/alexcrichton/openssl-probe ">openssl-probe 0.1.5</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot 0.12.3</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot_core 0.9.10</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding 2.3.1</a></li>
                     <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config 0.3.30</a></li>
-                    <li><a href=" https://github.com/proptest-rs/proptest ">proptest 1.4.0</a></li>
+                    <li><a href=" https://github.com/proptest-rs/proptest ">proptest 1.5.0</a></li>
                     <li><a href=" https://github.com/rust-lang/regex/tree/master/regex-automata ">regex-automata 0.4.7</a></li>
                     <li><a href=" https://github.com/rust-lang/regex/tree/master/regex-lite ">regex-lite 0.1.6</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.6.29</a></li>
                     <li><a href=" https://github.com/rust-lang/regex/tree/master/regex-syntax ">regex-syntax 0.8.4</a></li>
-                    <li><a href=" https://github.com/rust-lang/regex ">regex 1.10.5</a></li>
+                    <li><a href=" https://github.com/rust-lang/regex ">regex 1.10.6</a></li>
                     <li><a href=" https://github.com/rust-lang/rustc-demangle ">rustc-demangle 0.1.24</a></li>
                     <li><a href=" https://github.com/Kimundi/rustc-version-rs ">rustc_version 0.4.0</a></li>
                     <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 0.38.34</a></li>
                     <li><a href=" https://github.com/ctz/rustls-native-certs ">rustls-native-certs 0.6.3</a></li>
                     <li><a href=" https://github.com/rustls/pemfile ">rustls-pemfile 1.0.4</a></li>
-                    <li><a href=" https://github.com/rustls/pemfile ">rustls-pemfile 2.1.2</a></li>
+                    <li><a href=" https://github.com/rustls/pemfile ">rustls-pemfile 2.1.3</a></li>
                     <li><a href=" https://github.com/rustls/rustls ">rustls 0.21.12</a></li>
-                    <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.10</a></li>
                     <li><a href=" https://github.com/altsysrq/rusty-fork ">rusty-fork 0.3.0</a></li>
                     <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
                     <li><a href=" https://github.com/rustls/sct.rs ">sct 0.7.1</a></li>
-                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.11.0</a></li>
-                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 2.11.0</a></li>
-                    <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with 3.8.1</a></li>
-                    <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with_macros 3.8.1</a></li>
+                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.11.1</a></li>
+                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 2.11.1</a></li>
+                    <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with 3.9.0</a></li>
+                    <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with_macros 3.9.0</a></li>
                     <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry 1.4.2</a></li>
                     <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.13.2</a></li>
                     <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.5.7</a></li>
                     <li><a href=" https://github.com/dtolnay/syn ">syn 1.0.109</a></li>
-                    <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.10.1</a></li>
+                    <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.12.0</a></li>
                     <li><a href=" https://github.com/Amanieu/thread_local-rs ">thread_local 1.1.8</a></li>
-                    <li><a href=" https://github.com/idanarye/rust-typed-builder ">typed-builder-macro 0.18.2</a></li>
-                    <li><a href=" https://github.com/idanarye/rust-typed-builder ">typed-builder 0.18.2</a></li>
+                    <li><a href=" https://github.com/idanarye/rust-typed-builder ">typed-builder-macro 0.19.1</a></li>
+                    <li><a href=" https://github.com/idanarye/rust-typed-builder ">typed-builder 0.19.1</a></li>
                     <li><a href=" https://github.com/servo/unicode-bidi ">unicode-bidi 0.3.15</a></li>
                     <li><a href=" https://github.com/unicode-rs/unicode-normalization ">unicode-normalization 0.1.23</a></li>
+                    <li><a href=" https://github.com/unicode-rs/unicode-xid ">unicode-xid 0.2.4</a></li>
                     <li><a href=" https://github.com/servo/rust-url ">url 2.5.2</a></li>
-                    <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.8.0</a></li>
-                    <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.4</a></li>
+                    <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.10.0</a></li>
+                    <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.5</a></li>
                     <li><a href=" https://github.com/alexcrichton/wait-timeout ">wait-timeout 0.2.0</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasi ">wasi 0.11.0+wasi-snapshot-preview1</a></li>
-                    <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/backend ">wasm-bindgen-backend 0.2.92</a></li>
-                    <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.42</a></li>
-                    <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro-support ">wasm-bindgen-macro-support 0.2.92</a></li>
-                    <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro 0.2.92</a></li>
-                    <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.92</a></li>
-                    <li><a href=" https://github.com/rustwasm/wasm-bindgen ">wasm-bindgen 0.2.92</a></li>
-                    <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.69</a></li>
+                    <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/backend ">wasm-bindgen-backend 0.2.93</a></li>
+                    <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.43</a></li>
+                    <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro-support ">wasm-bindgen-macro-support 0.2.93</a></li>
+                    <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro 0.2.93</a></li>
+                    <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.93</a></li>
+                    <li><a href=" https://github.com/rustwasm/wasm-bindgen ">wasm-bindgen 0.2.93</a></li>
+                    <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.70</a></li>
                     <li><a href=" https://github.com/RazrFalcon/xmlparser ">xmlparser 0.13.6</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -7067,7 +6434,7 @@ limitations under the License.
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/base64ct ">base64ct 1.6.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.10.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/const-oid ">const-oid 0.9.6</a></li>
-                    <li><a href=" https://github.com/RustCrypto/utils ">cpufeatures 0.2.12</a></li>
+                    <li><a href=" https://github.com/RustCrypto/utils ">cpufeatures 0.2.13</a></li>
                     <li><a href=" https://github.com/RustCrypto/crypto-bigint ">crypto-bigint 0.4.9</a></li>
                     <li><a href=" https://github.com/RustCrypto/crypto-bigint ">crypto-bigint 0.5.5</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">crypto-common 0.1.6</a></li>
@@ -8484,31 +7851,20 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/seanmonstar/num_cpus ">num_cpus 1.16.0</a></li>
+                    <li><a href=" https://github.com/retep998/winapi-rs ">winapi 0.3.9</a></li>
                 </ul>
-                <pre class="license-text"># Contributing
-
-## License
-
-Licensed under either of
-
- * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
-
-at your option.
-
-### Contribution
-
-Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any
-additional terms or conditions.
+                <pre class="license-text">// Licensed under the Apache License, Version 2.0
+// &lt;LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0&gt; or the MIT license
+// &lt;LICENSE-MIT or http://opensource.org/licenses/MIT&gt;, at your option.
+// All files in the project carrying such notice may not be copied, modified, or distributed
+// except according to those terms.
 </pre>
             </li>
             <li class="license">
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/proptest-rs/proptest ">proptest 1.4.0</a></li>
+                    <li><a href=" https://github.com/proptest-rs/proptest ">proptest 1.5.0</a></li>
                 </ul>
                 <pre class="license-text">//-
 // Copyright 2017
@@ -8753,11 +8109,10 @@ limitations under the License.
                     <li><a href=" https://github.com/DanielKeep/rust-custom-derive/tree/custom_derive-master ">custom_derive 0.1.7</a></li>
                     <li><a href=" https://gitlab.com/kornelski/http-serde ">http-serde 2.1.1</a></li>
                     <li><a href=" https://github.com/TedDriggs/ident_case ">ident_case 1.0.1</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-lambda-rust-runtime ">lambda_runtime 0.11.3</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-lambda-rust-runtime ">lambda_runtime 0.12.0</a></li>
                     <li><a href=" https://github.com/awslabs/aws-lambda-rust-runtime ">lambda_runtime_api_client 0.11.1</a></li>
-                    <li><a href=" https://github.com/sfackler/rust-openssl ">openssl 0.10.64</a></li>
-                    <li><a href=" https://github.com/frozenlib/structmeta ">structmeta-derive 0.2.0</a></li>
-                    <li><a href=" https://github.com/frozenlib/structmeta ">structmeta 0.2.0</a></li>
+                    <li><a href=" https://github.com/frozenlib/structmeta ">structmeta-derive 0.3.0</a></li>
+                    <li><a href=" https://github.com/frozenlib/structmeta ">structmeta 0.3.0</a></li>
                     <li><a href=" https://github.com/mullvad/system-configuration-rs ">system-configuration-sys 0.5.0</a></li>
                     <li><a href=" https://github.com/mullvad/system-configuration-rs ">system-configuration 0.5.1</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi-i686-pc-windows-gnu 0.4.0</a></li>
@@ -8842,9 +8197,32 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/nical/android_system_properties ">android_system_properties 0.1.5</a></li>
+                    <li><a href=" https://github.com/sfackler/rust-openssl ">openssl 0.10.66</a></li>
                 </ul>
-                <pre class="license-text">Copyright 2016 Nicolas Silva
+                <pre class="license-text">Copyright 2011-2017 Google Inc.
+          2013 Jack Lloyd
+          2013-2014 Steven Fackler
+
+Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/comex/rust-shlex ">shlex 1.3.0</a></li>
+                </ul>
+                <pre class="license-text">Copyright 2015 Nicholas Allegra (comex).
 
 Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
 you may not use this file except in compliance with the License.
@@ -8864,6 +8242,7 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/unicode-rs/unicode-normalization ">unicode-normalization 0.1.23</a></li>
+                    <li><a href=" https://github.com/unicode-rs/unicode-xid ">unicode-xid 0.2.4</a></li>
                 </ul>
                 <pre class="license-text">Licensed under the Apache License, Version 2.0
 &lt;LICENSE-APACHE or
@@ -8883,260 +8262,13 @@ according to those terms.
                 <pre class="license-text">MIT OR Apache-2.0</pre>
             </li>
             <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/chronotope/chrono ">chrono 0.4.38</a></li>
-                </ul>
-                <pre class="license-text">Rust-chrono is dual-licensed under The MIT License [1] and
-Apache 2.0 License [2]. Copyright (c) 2014--2017, Kang Seonghoon and
-contributors.
-
-Nota Bene: This is same as the Rust Project&#x27;s own license.
-
-
-[1]: &lt;http://opensource.org/licenses/MIT&gt;, which is reproduced below:
-
-~~~~
-The MIT License (MIT)
-
-Copyright (c) 2014, Kang Seonghoon.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-~~~~
-
-
-[2]: &lt;http://www.apache.org/licenses/LICENSE-2.0&gt;, which is reproduced below:
-
-~~~~
-                              Apache License
-                        Version 2.0, January 2004
-                     http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-   and distribution as defined by Sections 1 through 9 of this document.
-
-   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-   the copyright owner that is granting the License.
-
-   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-   other entities that control, are controlled by, or are under common
-   control with that entity. For the purposes of this definition,
-   &quot;control&quot; means (i) the power, direct or indirect, to cause the
-   direction or management of such entity, whether by contract or
-   otherwise, or (ii) ownership of fifty percent (50%) or more of the
-   outstanding shares, or (iii) beneficial ownership of such entity.
-
-   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-   exercising permissions granted by this License.
-
-   &quot;Source&quot; form shall mean the preferred form for making modifications,
-   including but not limited to software source code, documentation
-   source, and configuration files.
-
-   &quot;Object&quot; form shall mean any form resulting from mechanical
-   transformation or translation of a Source form, including but
-   not limited to compiled object code, generated documentation,
-   and conversions to other media types.
-
-   &quot;Work&quot; shall mean the work of authorship, whether in Source or
-   Object form, made available under the License, as indicated by a
-   copyright notice that is included in or attached to the work
-   (an example is provided in the Appendix below).
-
-   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-   form, that is based on (or derived from) the Work and for which the
-   editorial revisions, annotations, elaborations, or other modifications
-   represent, as a whole, an original work of authorship. For the purposes
-   of this License, Derivative Works shall not include works that remain
-   separable from, or merely link (or bind by name) to the interfaces of,
-   the Work and Derivative Works thereof.
-
-   &quot;Contribution&quot; shall mean any work of authorship, including
-   the original version of the Work and any modifications or additions
-   to that Work or Derivative Works thereof, that is intentionally
-   submitted to Licensor for inclusion in the Work by the copyright owner
-   or by an individual or Legal Entity authorized to submit on behalf of
-   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-   means any form of electronic, verbal, or written communication sent
-   to the Licensor or its representatives, including but not limited to
-   communication on electronic mailing lists, source code control systems,
-   and issue tracking systems that are managed by, or on behalf of, the
-   Licensor for the purpose of discussing and improving the Work, but
-   excluding communication that is conspicuously marked or otherwise
-   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-   on behalf of whom a Contribution has been received by Licensor and
-   subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   copyright license to reproduce, prepare Derivative Works of,
-   publicly display, publicly perform, sublicense, and distribute the
-   Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   (except as stated in this section) patent license to make, have made,
-   use, offer to sell, sell, import, and otherwise transfer the Work,
-   where such license applies only to those patent claims licensable
-   by such Contributor that are necessarily infringed by their
-   Contribution(s) alone or by combination of their Contribution(s)
-   with the Work to which such Contribution(s) was submitted. If You
-   institute patent litigation against any entity (including a
-   cross-claim or counterclaim in a lawsuit) alleging that the Work
-   or a Contribution incorporated within the Work constitutes direct
-   or contributory patent infringement, then any patent licenses
-   granted to You under this License for that Work shall terminate
-   as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-   Work or Derivative Works thereof in any medium, with or without
-   modifications, and in Source or Object form, provided that You
-   meet the following conditions:
-
-   (a) You must give any other recipients of the Work or
-       Derivative Works a copy of this License; and
-
-   (b) You must cause any modified files to carry prominent notices
-       stating that You changed the files; and
-
-   (c) You must retain, in the Source form of any Derivative Works
-       that You distribute, all copyright, patent, trademark, and
-       attribution notices from the Source form of the Work,
-       excluding those notices that do not pertain to any part of
-       the Derivative Works; and
-
-   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-       distribution, then any Derivative Works that You distribute must
-       include a readable copy of the attribution notices contained
-       within such NOTICE file, excluding those notices that do not
-       pertain to any part of the Derivative Works, in at least one
-       of the following places: within a NOTICE text file distributed
-       as part of the Derivative Works; within the Source form or
-       documentation, if provided along with the Derivative Works; or,
-       within a display generated by the Derivative Works, if and
-       wherever such third-party notices normally appear. The contents
-       of the NOTICE file are for informational purposes only and
-       do not modify the License. You may add Your own attribution
-       notices within Derivative Works that You distribute, alongside
-       or as an addendum to the NOTICE text from the Work, provided
-       that such additional attribution notices cannot be construed
-       as modifying the License.
-
-   You may add Your own copyright statement to Your modifications and
-   may provide additional or different license terms and conditions
-   for use, reproduction, or distribution of Your modifications, or
-   for any such Derivative Works as a whole, provided Your use,
-   reproduction, and distribution of the Work otherwise complies with
-   the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-   any Contribution intentionally submitted for inclusion in the Work
-   by You to the Licensor shall be under the terms and conditions of
-   this License, without any additional terms or conditions.
-   Notwithstanding the above, nothing herein shall supersede or modify
-   the terms of any separate license agreement you may have executed
-   with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade
-   names, trademarks, service marks, or product names of the Licensor,
-   except as required for reasonable and customary use in describing the
-   origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-   agreed to in writing, Licensor provides the Work (and each
-   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied, including, without limitation, any warranties or conditions
-   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-   PARTICULAR PURPOSE. You are solely responsible for determining the
-   appropriateness of using or redistributing the Work and assume any
-   risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-   whether in tort (including negligence), contract, or otherwise,
-   unless required by applicable law (such as deliberate and grossly
-   negligent acts) or agreed to in writing, shall any Contributor be
-   liable to You for damages, including any direct, indirect, special,
-   incidental, or consequential damages of any character arising as a
-   result of this License or out of the use or inability to use the
-   Work (including but not limited to damages for loss of goodwill,
-   work stoppage, computer failure or malfunction, or any and all
-   other commercial damages or losses), even if such Contributor
-   has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-   the Work or Derivative Works thereof, You may choose to offer,
-   and charge a fee for, acceptance of support, warranty, indemnity,
-   or other liability obligations and/or rights consistent with this
-   License. However, in accepting such obligations, You may act only
-   on Your own behalf and on Your sole responsibility, not on behalf
-   of any other Contributor, and only if You agree to indemnify,
-   defend, and hold each Contributor harmless for any liability
-   incurred by, or claims asserted against, such Contributor by reason
-   of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-   replaced with your own identifying information. (Don&#x27;t include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same &quot;printed page&quot; as the copyright notice for easier
-   identification within third-party archives.
-
-Copyright [yyyy] [name of copyright owner]
-
-Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-~~~~
-
-</pre>
-            </li>
-            <li class="license">
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/dalek-cryptography/subtle ">subtle 2.5.0</a></li>
+                    <li><a href=" https://github.com/dalek-cryptography/subtle ">subtle 2.6.1</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2016-2017 Isis Agora Lovecruft, Henry de Valence. All rights reserved.
+Copyright (c) 2016-2024 Isis Agora Lovecruft. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -9164,25 +8296,6 @@ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/briansmith/ring ">ring 0.17.8</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) &lt;year&gt; &lt;owner&gt;. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 </pre>
             </li>
             <li class="license">
@@ -9223,6 +8336,47 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/briansmith/ring ">ring 0.17.8</a></li>
+                </ul>
+                <pre class="license-text">   Copyright 2015-2016 Brian Smith.
+
+   Permission to use, copy, modify, and/or distribute this software for any
+   purpose with or without fee is hereby granted, provided that the above
+   copyright notice and this permission notice appear in all copies.
+
+   THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND THE AUTHORS DISCLAIM ALL WARRANTIES
+   WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+   MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+   SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+   WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+   OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+   CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</pre>
+            </li>
+            <li class="license">
+                <h3 id="ISC">ISC License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/briansmith/ring ">ring 0.17.8</a></li>
+                </ul>
+                <pre class="license-text">/* Copyright (c) 2015, Google Inc.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+ * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="ISC">ISC License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/briansmith/untrusted ">untrusted 0.9.0</a></li>
                 </ul>
                 <pre class="license-text">// Copyright 2015-2016 Brian Smith.
@@ -9244,9 +8398,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/briansmith/ring ">ring 0.17.8</a></li>
                     <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.101.7</a></li>
-                    <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.102.4</a></li>
                 </ul>
                 <pre class="license-text">ISC License:
 
@@ -9262,7 +8414,7 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND ISC DISCLAIMS ALL WARRANTIES WITH
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/sfackler/rust-openssl ">openssl-sys 0.9.102</a></li>
+                    <li><a href=" https://github.com/sfackler/rust-openssl ">openssl-sys 0.9.103</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014 Alex Crichton
 
@@ -9295,7 +8447,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/mio ">mio 0.8.11</a></li>
+                    <li><a href=" https://github.com/tokio-rs/mio ">mio 1.0.2</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014 Carl Lerche and other MIO contributors
 
@@ -9322,8 +8474,8 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/hyper ">hyper 0.14.29</a></li>
-                    <li><a href=" https://github.com/hyperium/hyper ">hyper 1.3.1</a></li>
+                    <li><a href=" https://github.com/hyperium/hyper ">hyper 0.14.30</a></li>
+                    <li><a href=" https://github.com/hyperium/hyper ">hyper 1.4.1</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014-2021 Sean McArthur
 
@@ -9425,7 +8577,35 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://gitlab.redox-os.org/redox-os/syscall ">redox_syscall 0.5.2</a></li>
+                    <li><a href=" https://github.com/briansmith/ring ">ring 0.17.8</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2015-2016 the fiat-crypto authors (see
+https://github.com/mit-plv/fiat-crypto/blob/master/AUTHORS).
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://gitlab.redox-os.org/redox-os/syscall ">redox_syscall 0.5.3</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2017 Redox OS Developers
 
@@ -9489,7 +8669,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/bytes ">bytes 1.6.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/bytes ">bytes 1.7.1</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2018 Carl Lerche
 
@@ -9609,6 +8789,66 @@ THE SOFTWARE.
                     <li><a href=" https://github.com/tokio-rs/slab ">slab 0.4.9</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2019 Carl Lerche
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the &quot;Software&quot;), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/tokio-rs/async-stream ">async-stream-impl 0.3.5</a></li>
+                    <li><a href=" https://github.com/tokio-rs/async-stream ">async-stream 0.3.5</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2019 Carl Lerche
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the &quot;Software&quot;), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+Copyright (c) 2018 David Tolnay
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -9766,8 +9006,8 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tower-rs/tower ">tower-layer 0.3.2</a></li>
-                    <li><a href=" https://github.com/tower-rs/tower ">tower-service 0.3.2</a></li>
+                    <li><a href=" https://github.com/tower-rs/tower ">tower-layer 0.3.3</a></li>
+                    <li><a href=" https://github.com/tower-rs/tower ">tower-service 0.3.3</a></li>
                     <li><a href=" https://github.com/tower-rs/tower ">tower 0.4.13</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2019 Tower Contributors
@@ -9801,7 +9041,40 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/hyper-util ">hyper-util 0.1.5</a></li>
+                    <li><a href=" https://github.com/hyperium/http-body ">http-body 1.0.1</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2019-2024 Sean McArthur &amp; Hyper Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the &quot;Software&quot;), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/hyperium/hyper-util ">hyper-util 0.1.7</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2023 Sean McArthur
 
@@ -9863,7 +9136,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/jeromefroe/lru-rs.git ">lru 0.12.3</a></li>
+                    <li><a href=" https://github.com/jeromefroe/lru-rs.git ">lru 0.12.4</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -9891,9 +9164,9 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/TedDriggs/darling ">darling 0.20.9</a></li>
-                    <li><a href=" https://github.com/TedDriggs/darling ">darling_core 0.20.9</a></li>
-                    <li><a href=" https://github.com/TedDriggs/darling ">darling_macro 0.20.9</a></li>
+                    <li><a href=" https://github.com/TedDriggs/darling ">darling 0.20.10</a></li>
+                    <li><a href=" https://github.com/TedDriggs/darling ">darling_core 0.20.10</a></li>
+                    <li><a href=" https://github.com/TedDriggs/darling ">darling_macro 0.20.10</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -9982,7 +9255,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.3.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.4.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -10040,13 +9313,8 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/async-stream ">async-stream-impl 0.3.5</a></li>
-                    <li><a href=" https://github.com/tokio-rs/async-stream ">async-stream 0.3.5</a></li>
                     <li><a href=" https://github.com/Nugine/simd ">base64-simd 0.8.0</a></li>
-                    <li><a href=" https://github.com/rutrum/convert-case ">convert_case 0.4.0</a></li>
                     <li><a href=" https://github.com/danielhenrymantilla/rust-function_name ">function_name-proc-macro 0.3.0</a></li>
-                    <li><a href=" https://github.com/hyperium/http-body ">http-body 1.0.0</a></li>
-                    <li><a href=" https://github.com/briansmith/ring ">ring 0.17.8</a></li>
                     <li><a href=" https://github.com/tokio-rs/valuable ">valuable 0.1.0</a></li>
                     <li><a href=" https://github.com/Nugine/simd ">vsimd 0.8.0</a></li>
                 </ul>
@@ -10065,7 +9333,7 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.38.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.39.2</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -10180,7 +9448,36 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/BurntSushi/aho-corasick ">aho-corasick 1.1.3</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-core 0.1.32</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2014 Mathijs van de Nes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/BurntSushi/byteorder ">byteorder 1.5.0</a></li>
                     <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.7.4</a></li>
                     <li><a href=" https://github.com/BurntSushi/regex-automata ">regex-automata 0.1.10</a></li>
                 </ul>
@@ -10242,7 +9539,8 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/JelteF/derive_more ">derive_more 0.99.18</a></li>
+                    <li><a href=" https://github.com/JelteF/derive_more ">derive_more-impl 1.0.0</a></li>
+                    <li><a href=" https://github.com/JelteF/derive_more ">derive_more 1.0.0</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -10299,7 +9597,8 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/BurntSushi/aho-corasick ">aho-corasick 1.1.3</a></li>
+                    <li><a href=" https://github.com/BurntSushi/byteorder ">byteorder 1.5.0</a></li>
+                    <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.7.4</a></li>
                     <li><a href=" https://github.com/BurntSushi/regex-automata ">regex-automata 0.1.10</a></li>
                 </ul>
                 <pre class="license-text">This project is dual-licensed under the Unlicense and MIT licenses.
@@ -10336,68 +9635,64 @@ THE SOFTWARE.
 </pre>
             </li>
             <li class="license">
-                <h3 id="NOASSERTION">NOASSERTION</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/briansmith/ring ">ring 0.17.8</a></li>
-                </ul>
-                <pre class="license-text"></pre>
-            </li>
-            <li class="license">
                 <h3 id="OpenSSL">OpenSSL License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/briansmith/ring ">ring 0.17.8</a></li>
                 </ul>
-                <pre class="license-text">OpenSSL License
-
-Copyright (c) 1998-2008 The OpenSSL Project. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. All advertising materials mentioning features or use of this software must display the following acknowledgment: &quot;This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit. (http://www.openssl.org/)&quot;
-
-4. The names &quot;OpenSSL Toolkit&quot; and &quot;OpenSSL Project&quot; must not be used to endorse or promote products derived from this software without prior written permission. For written permission, please contact openssl-core@openssl.org.
-
-5. Products derived from this software may not be called &quot;OpenSSL&quot; nor may &quot;OpenSSL&quot; appear in their names without prior written permission of the OpenSSL Project.
-
-6. Redistributions of any form whatsoever must retain the following acknowledgment: &quot;This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit (http://www.openssl.org/)&quot;
-
-THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT &#x60;&#x60;AS IS&#x27;&#x27; AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE OpenSSL PROJECT OR ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-This product includes cryptographic software written by Eric Young (eay@cryptsoft.com). This product includes software written by Tim Hudson (tjh@cryptsoft.com).
-
-
-Original SSLeay License
-
-Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com) All rights reserved.
-
-This package is an SSL implementation written by Eric Young (eay@cryptsoft.com). The implementation was written so as to conform with Netscapes SSL.
-
-This library is free for commercial and non-commercial use as long as the following conditions are aheared to. The following conditions apply to all code found in this distribution, be it the RC4, RSA, lhash, DES, etc., code; not just the SSL code. The SSL documentation included with this distribution is covered by the same copyright terms except that the holder is Tim Hudson (tjh@cryptsoft.com).
-
-Copyright remains Eric Young&#x27;s, and as such any Copyright notices in the code are not to be removed. If this package is used in a product, Eric Young should be given attribution as the author of the parts of the library used. This can be in the form of a textual message at program startup or in documentation (online or textual) provided with the package.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the copyright notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. All advertising materials mentioning features or use of this software must display the following acknowledgement:
-&quot;This product includes cryptographic software written by Eric Young (eay@cryptsoft.com)&quot;
-The word &#x27;cryptographic&#x27; can be left out if the rouines from the library being used are not cryptographic related :-).
-
-4. If you include any Windows specific code (or a derivative thereof) from the apps directory (application code) you must include an acknowledgement: &quot;This product includes software written by Tim Hudson (tjh@cryptsoft.com)&quot;
-
-THIS SOFTWARE IS PROVIDED BY ERIC YOUNG &#x60;&#x60;AS IS&#x27;&#x27; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-The licence and distribution terms for any publically available version or derivative of this code cannot be changed. i.e. this code cannot simply be copied and put under another distribution licence [including the GNU Public Licence.]
-</pre>
+                <pre class="license-text">/* &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
+ * Copyright (c) 1998-2011 The OpenSSL Project.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer. 
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. All advertising materials mentioning features or use of this
+ *    software must display the following acknowledgment:
+ *    &quot;This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit. (http://www.openssl.org/)&quot;
+ *
+ * 4. The names &quot;OpenSSL Toolkit&quot; and &quot;OpenSSL Project&quot; must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For written permission, please contact
+ *    openssl-core@openssl.org.
+ *
+ * 5. Products derived from this software may not be called &quot;OpenSSL&quot;
+ *    nor may &quot;OpenSSL&quot; appear in their names without prior written
+ *    permission of the OpenSSL Project.
+ *
+ * 6. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    &quot;This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit (http://www.openssl.org/)&quot;
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT &#x60;&#x60;AS IS&#x27;&#x27; AND ANY
+ * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+ * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
+ *
+ * This product includes cryptographic software written by Eric Young
+ * (eay@cryptsoft.com).  This product includes software written by Tim
+ * Hudson (tjh@cryptsoft.com).
+ *
+ */</pre>
             </li>
             <li class="license">
                 <h3 id="Unicode-DFS-2016">Unicode License Agreement - Data Files and Software (2016)</h3>


### PR DESCRIPTION
## What

Update derive_more dependency to 1.0.

## Why

derive_more now has a  stable version.

## Depends on

None

## Concerns

Minimum supported Rust version (MSRV) is 1.75.

## Notes

This section is also optional and should include anything else that you would like to discuss in the PR review that is not captured elsewhere.

* See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info.
