### PR TITLE
feat: add s3event to run lambda handler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ aws-sdk-sqs = { version = "1.22.0", optional = true }
 aws-smithy-async = { version = "1.2.1", optional = true }
 aws-smithy-runtime-api = "1.5.0"
 aws-types = "1.2.0"
-aws_lambda_events = { version = "0.15", default-features = false, features = ["sqs"], optional = true }
+aws_lambda_events = { version = "0.15", default-features = false, features = ["sqs", "s3"], optional = true }
 bytes = "1.6.0"
 bytesize = "1.3"
 clap = { version = "4.5", features = ["derive", "env"] }

--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -7,6 +7,7 @@
 
 use anyhow::{Context as _, Result};
 use async_trait::async_trait;
+pub use aws_lambda_events::event::s3::S3Event;
 /// Re-export from [aws_lambda_events::event::sqs::SqsEvent], with [RunnableEventType] implemented.
 pub use aws_lambda_events::event::sqs::SqsEvent;
 use clap::Parser;
@@ -147,6 +148,17 @@ impl<T: StepFunctionEvent, MsgResult> RunnableEventType<T, MsgResult, MsgResult>
         Fut: Future<Output = Result<MsgResult>>,
     {
         message_handler(self.clone(), ctx).await
+    }
+}
+
+#[async_trait(?Send)]
+impl RunnableEventType<S3Event, (), ()> for S3Event {
+    async fn process<F, Fut, Context>(&self, message_handler: F, ctx: Arc<Context>) -> Result<()>
+    where
+        F: Fn(S3Event, Arc<Context>) -> Fut,
+        Fut: Future<Output = Result<()>>,
+    {
+        Ok(message_handler(self.clone(), ctx).await?)
     }
 }
 


### PR DESCRIPTION
## What

Adds S3Event as a RunnableEventType 

## Why

So that lambdas can be triggered on S3Events

