### PR TITLE
task: Upgrade cargo version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
 
   cargo:
-    image: ghcr.io/harrison-ai/rust:1.77-1.0
+    image: ghcr.io/harrison-ai/rust:1.81-0.0
     entrypoint: cargo
     volumes:
       - '~/.cargo/registry:/usr/local/cargo/registry'


### PR DESCRIPTION
## What

This PR update `cargo` to use the latest `1.81` release.

## Why

This lets us take advantage of the latest updates to the `cargo` toolchain.
