### PR TITLE
task: Remove obsolete version from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
 
   cargo:


### PR DESCRIPTION
## What

This PR removes the `version` field from `docker-compose.yml`.

## Why

This field is obsolete, and generates warnings in CI.
