### PR TITLE
chore: Prepare release 0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.15.2
+
+  - Updated rust crate `aws_lambda_events` to `0.16.0`.
+
 ## 0.15.1
 
   - Replaced use of the unmaintained `derivative` crate with `derive_more`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cobalt-aws"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["harrison.ai Data Engineering <dataengineering@harrison.ai>"]
 edition = "2021"
 description = "This library provides a collection of wrappers around the aws-sdk-rust and lambda_runtime packages."

--- a/licenses/licenses.html
+++ b/licenses/licenses.html
@@ -46,13 +46,12 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (215)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (216)</li>
             <li><a href="#MIT">MIT License</a> (64)</li>
-            <li><a href="#Unicode-3.0">Unicode License v3</a> (19)</li>
+            <li><a href="#Unicode-3.0">Unicode License v3</a> (20)</li>
             <li><a href="#ISC">ISC License</a> (4)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (2)</li>
             <li><a href="#OpenSSL">OpenSSL License</a> (1)</li>
-            <li><a href="#Unicode-DFS-2016">Unicode License Agreement - Data Files and Software (2016)</a> (1)</li>
             <li><a href="#Zlib">zlib License</a> (1)</li>
         </ul>
 
@@ -62,19 +61,19 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/harrison-ai/cobalt-aws/ ">cobalt-aws 0.15.1</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-config 1.5.10</a></li>
+                    <li><a href=" https://github.com/harrison-ai/cobalt-aws/ ">cobalt-aws 0.15.2</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-config 1.5.13</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-credential-types 1.2.1</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-runtime 1.4.3</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-async 1.2.1</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-runtime 1.5.3</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-async 1.2.3</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-checksums 0.60.13</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-eventstream 0.60.5</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http 0.60.11</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-json 0.60.7</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-json 0.61.1</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-query 0.60.7</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime-api 1.7.3</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime 1.7.3</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-types 1.2.9</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime 1.7.6</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-types 1.2.11</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-xml 0.60.9</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-types 1.3.3</a></li>
                 </ul>
@@ -262,7 +261,7 @@
                     <li><a href=" https://github.com/taiki-e/pin-project ">pin-project-internal 1.1.7</a></li>
                     <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.15</a></li>
                     <li><a href=" https://github.com/taiki-e/pin-project ">pin-project 1.1.7</a></li>
-                    <li><a href=" https://github.com/Actyx/sync_wrapper ">sync_wrapper 1.0.1</a></li>
+                    <li><a href=" https://github.com/Actyx/sync_wrapper ">sync_wrapper 1.0.2</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -1078,7 +1077,7 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/time-rs/time ">time 0.3.36</a></li>
+                    <li><a href=" https://github.com/time-rs/time ">time 0.3.37</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -1288,7 +1287,7 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-sigv4 1.2.5</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-sigv4 1.2.6</a></li>
                     <li><a href=" https://github.com/hsivonen/encoding_rs ">encoding_rs 0.8.35</a></li>
                     <li><a href=" https://github.com/hsivonen/utf16_iter ">utf16_iter 1.0.5</a></li>
                     <li><a href=" https://github.com/hsivonen/utf8_iter ">utf8_iter 1.0.4</a></li>
@@ -1503,7 +1502,8 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 0.38.40</a></li>
+                    <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.4.14</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 0.38.42</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -1731,7 +1731,7 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/wvwwvwwv/scalable-delayed-dealloc/ ">sdd 3.0.4</a></li>
+                    <li><a href=" https://github.com/wvwwvwwv/scalable-delayed-dealloc/ ">sdd 3.0.5</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, April 2004
@@ -2140,9 +2140,9 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.5.20</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.5.23</a></li>
                     <li><a href=" https://github.com/clap-rs/clap ">clap_derive 4.5.18</a></li>
-                    <li><a href=" https://github.com/clap-rs/clap ">clap_lex 0.7.2</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap_lex 0.7.4</a></li>
                     <li><a href=" https://github.com/frozenlib/test-strategy ">test-strategy 0.4.0</a></li>
                     <li><a href=" https://github.com/cameron1024/unarray ">unarray 0.1.4</a></li>
                 </ul>
@@ -2775,7 +2775,7 @@ Software.
                     <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-query 1.1.2</a></li>
                     <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.10</a></li>
                     <li><a href=" https://github.com/hyunsik/bytesize/ ">bytesize 1.3.0</a></li>
-                    <li><a href=" https://github.com/clap-rs/clap ">clap 4.5.20</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap 4.5.23</a></li>
                     <li><a href=" https://github.com/rust-cli/anstyle.git ">colorchoice 1.0.3</a></li>
                     <li><a href=" https://github.com/srijs/rust-crc32fast ">crc32fast 1.4.2</a></li>
                     <li><a href=" https://github.com/sfackler/foreign-types ">foreign-types-shared 0.1.1</a></li>
@@ -2994,7 +2994,7 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/wvwwvwwv/scalable-concurrent-containers/ ">scc 2.2.4</a></li>
+                    <li><a href=" https://github.com/wvwwvwwv/scalable-concurrent-containers/ ">scc 2.3.0</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3192,12 +3192,12 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-athena 1.53.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-s3 1.60.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sqs 1.49.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sso 1.49.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-ssooidc 1.50.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sts 1.49.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-athena 1.57.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-s3 1.68.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sqs 1.53.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sso 1.53.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-ssooidc 1.54.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sts 1.54.0</a></li>
                 </ul>
                 <pre class="license-text">                                Apache License
                            Version 2.0, January 2004
@@ -3407,25 +3407,25 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.19</a></li>
-                    <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.93</a></li>
-                    <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.83</a></li>
-                    <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.11</a></li>
-                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.162</a></li>
-                    <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.89</a></li>
-                    <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.37</a></li>
+                    <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.95</a></li>
+                    <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.84</a></li>
+                    <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.14</a></li>
+                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.169</a></li>
+                    <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.92</a></li>
+                    <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.38</a></li>
                     <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.18</a></li>
-                    <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.23</a></li>
-                    <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.214</a></li>
-                    <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.214</a></li>
-                    <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.132</a></li>
+                    <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.24</a></li>
+                    <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.217</a></li>
+                    <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.217</a></li>
+                    <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.134</a></li>
                     <li><a href=" https://github.com/dtolnay/path-to-error ">serde_path_to_error 0.1.16</a></li>
                     <li><a href=" https://github.com/nox/serde_urlencoded ">serde_urlencoded 0.7.1</a></li>
-                    <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.87</a></li>
-                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 1.0.69</a></li>
-                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 1.0.69</a></li>
-                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.13</a></li>
+                    <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.95</a></li>
+                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 2.0.9</a></li>
+                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 2.0.9</a></li>
+                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.14</a></li>
                     <li><a href=" https://github.com/alacritty/vte ">utf8parse 0.2.2</a></li>
+                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.7.35</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -4035,7 +4035,7 @@ limitations under the License.</pre>
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/seanmonstar/reqwest ">reqwest 0.12.9</a></li>
+                    <li><a href=" https://github.com/seanmonstar/reqwest ">reqwest 0.12.12</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -4245,7 +4245,7 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/hyperium/http ">http 0.2.12</a></li>
-                    <li><a href=" https://github.com/hyperium/http ">http 1.1.0</a></li>
+                    <li><a href=" https://github.com/hyperium/http ">http 1.2.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5500,7 +5500,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.10.0</a></li>
+                    <li><a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.10.1</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5716,24 +5716,24 @@ limitations under the License.
                     <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.22.1</a></li>
                     <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.6.0</a></li>
                     <li><a href=" https://github.com/vorner/bytes-utils ">bytes-utils 0.1.4</a></li>
-                    <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.1.37</a></li>
+                    <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.7</a></li>
                     <li><a href=" https://github.com/alexcrichton/cfg-if ">cfg-if 1.0.0</a></li>
                     <li><a href=" https://github.com/yaahc/displaydoc ">displaydoc 0.2.5</a></li>
                     <li><a href=" https://github.com/rayon-rs/either ">either 1.13.0</a></li>
                     <li><a href=" https://github.com/cuviper/equivalent ">equivalent 1.0.1</a></li>
-                    <li><a href=" https://github.com/lambda-fairy/rust-errno ">errno 0.3.9</a></li>
-                    <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.2.0</a></li>
+                    <li><a href=" https://github.com/lambda-fairy/rust-errno ">errno 0.3.10</a></li>
+                    <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.3.0</a></li>
                     <li><a href=" https://github.com/servo/rust-fnv ">fnv 1.0.7</a></li>
                     <li><a href=" https://github.com/servo/rust-url ">form_urlencoded 1.2.1</a></li>
                     <li><a href=" https://github.com/zkcrypto/group ">group 0.12.1</a></li>
-                    <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.15.1</a></li>
+                    <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.15.2</a></li>
                     <li><a href=" https://github.com/withoutboats/heck ">heck 0.5.0</a></li>
                     <li><a href=" https://github.com/seanmonstar/httparse ">httparse 1.9.5</a></li>
                     <li><a href=" https://github.com/rustls/hyper-rustls ">hyper-rustls 0.24.2</a></li>
                     <li><a href=" https://github.com/hyperium/hyper-tls ">hyper-tls 0.6.0</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">idna 1.0.3</a></li>
                     <li><a href=" https://github.com/hsivonen/idna_adapter ">idna_adapter 1.2.0</a></li>
-                    <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.6.0</a></li>
+                    <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.7.0</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static 1.5.0</a></li>
                     <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.4.14</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.12</a></li>
@@ -5747,14 +5747,14 @@ limitations under the License.
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot_core 0.9.10</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding 2.3.1</a></li>
                     <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config 0.3.31</a></li>
-                    <li><a href=" https://github.com/proptest-rs/proptest ">proptest 1.5.0</a></li>
-                    <li><a href=" https://github.com/rust-lang/regex/tree/master/regex-automata ">regex-automata 0.4.8</a></li>
+                    <li><a href=" https://github.com/proptest-rs/proptest ">proptest 1.6.0</a></li>
+                    <li><a href=" https://github.com/rust-lang/regex/tree/master/regex-automata ">regex-automata 0.4.9</a></li>
                     <li><a href=" https://github.com/rust-lang/regex/tree/master/regex-lite ">regex-lite 0.1.6</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.6.29</a></li>
                     <li><a href=" https://github.com/rust-lang/regex/tree/master/regex-syntax ">regex-syntax 0.8.5</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex 1.11.1</a></li>
                     <li><a href=" https://github.com/djc/rustc-version-rs ">rustc_version 0.4.1</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 0.38.40</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 0.38.42</a></li>
                     <li><a href=" https://github.com/ctz/rustls-native-certs ">rustls-native-certs 0.6.3</a></li>
                     <li><a href=" https://github.com/rustls/pemfile ">rustls-pemfile 1.0.4</a></li>
                     <li><a href=" https://github.com/rustls/pemfile ">rustls-pemfile 2.2.0</a></li>
@@ -5762,18 +5762,18 @@ limitations under the License.
                     <li><a href=" https://github.com/altsysrq/rusty-fork ">rusty-fork 0.3.0</a></li>
                     <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
                     <li><a href=" https://github.com/rustls/sct.rs ">sct 0.7.1</a></li>
-                    <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with 3.11.0</a></li>
-                    <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with_macros 3.11.0</a></li>
+                    <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with 3.12.0</a></li>
+                    <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with_macros 3.12.0</a></li>
                     <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry 1.4.2</a></li>
                     <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.13.2</a></li>
-                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.5.7</a></li>
+                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.5.8</a></li>
                     <li><a href=" https://github.com/storyyeller/stable_deref_trait ">stable_deref_trait 1.2.0</a></li>
-                    <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.14.0</a></li>
+                    <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.15.0</a></li>
                     <li><a href=" https://github.com/Amanieu/thread_local-rs ">thread_local 1.1.8</a></li>
                     <li><a href=" https://github.com/idanarye/rust-typed-builder ">typed-builder-macro 0.20.0</a></li>
                     <li><a href=" https://github.com/idanarye/rust-typed-builder ">typed-builder 0.20.0</a></li>
                     <li><a href=" https://github.com/unicode-rs/unicode-xid ">unicode-xid 0.2.6</a></li>
-                    <li><a href=" https://github.com/servo/rust-url ">url 2.5.3</a></li>
+                    <li><a href=" https://github.com/servo/rust-url ">url 2.5.4</a></li>
                     <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.11.0</a></li>
                     <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.5</a></li>
                     <li><a href=" https://github.com/alexcrichton/wait-timeout ">wait-timeout 0.2.0</a></li>
@@ -6196,8 +6196,8 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/contain-rs/bit-set ">bit-set 0.5.3</a></li>
-                    <li><a href=" https://github.com/contain-rs/bit-vec ">bit-vec 0.6.3</a></li>
+                    <li><a href=" https://github.com/contain-rs/bit-set ">bit-set 0.8.0</a></li>
+                    <li><a href=" https://github.com/contain-rs/bit-vec ">bit-vec 0.8.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -6410,7 +6410,7 @@ limitations under the License.
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/base64ct ">base64ct 1.6.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.10.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/const-oid ">const-oid 0.9.6</a></li>
-                    <li><a href=" https://github.com/RustCrypto/utils ">cpufeatures 0.2.14</a></li>
+                    <li><a href=" https://github.com/RustCrypto/utils ">cpufeatures 0.2.16</a></li>
                     <li><a href=" https://github.com/RustCrypto/crypto-bigint ">crypto-bigint 0.4.9</a></li>
                     <li><a href=" https://github.com/RustCrypto/crypto-bigint ">crypto-bigint 0.5.5</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">crypto-common 0.1.6</a></li>
@@ -6818,6 +6818,201 @@ END OF TERMS AND CONDITIONS
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/rust-random/rand ">rand_core 0.6.4</a></li>
+                </ul>
+                <pre class="license-text">                              Apache License
+                        Version 2.0, January 2004
+                     https://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   &quot;control&quot; means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   &quot;Source&quot; form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   &quot;Object&quot; form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   &quot;Work&quot; shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   &quot;Contribution&quot; shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+   replaced with your own identifying information. (Don&#x27;t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same &quot;printed page&quot; as the copyright notice for easier
+   identification within third-party archives.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.2.15</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.3.1</a></li>
                     <li><a href=" https://github.com/rust-random/rngs ">rand_xorshift 0.3.0</a></li>
@@ -7029,6 +7224,190 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
+                </ul>
+                <pre class="license-text">                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   &quot;control&quot; means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   &quot;Source&quot; form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   &quot;Object&quot; form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   &quot;Work&quot; shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   &quot;Contribution&quot; shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/mcgoo/vcpkg-rs ">vcpkg 0.2.15</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -7233,22 +7612,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/proptest-rs/proptest ">proptest 1.5.0</a></li>
-                </ul>
-                <pre class="license-text">//-
-// Copyright 2017
-//
-// Licensed under the Apache License, Version 2.0 &lt;LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0&gt; or the MIT license
-// &lt;LICENSE-MIT or http://opensource.org/licenses/MIT&gt;, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
 </pre>
             </li>
             <li class="license">
@@ -7480,14 +7843,13 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/chronotope/chrono ">chrono 0.4.38</a></li>
+                    <li><a href=" https://github.com/chronotope/chrono ">chrono 0.4.39</a></li>
                     <li><a href=" https://github.com/zowens/crc32c ">crc32c 0.6.8</a></li>
                     <li><a href=" https://github.com/DanielKeep/rust-custom-derive/tree/custom_derive-master ">custom_derive 0.1.7</a></li>
                     <li><a href=" https://gitlab.com/kornelski/http-serde ">http-serde 2.1.1</a></li>
                     <li><a href=" https://github.com/TedDriggs/ident_case ">ident_case 1.0.1</a></li>
                     <li><a href=" https://github.com/awslabs/aws-lambda-rust-runtime ">lambda_runtime 0.13.0</a></li>
                     <li><a href=" https://github.com/awslabs/aws-lambda-rust-runtime ">lambda_runtime_api_client 0.11.1</a></li>
-                    <li><a href=" https://github.com/rust-random/rand ">rand_core 0.6.4</a></li>
                     <li><a href=" https://github.com/frozenlib/structmeta ">structmeta-derive 0.3.0</a></li>
                     <li><a href=" https://github.com/frozenlib/structmeta ">structmeta 0.3.0</a></li>
                 </ul>
@@ -7819,7 +8181,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/mio ">mio 1.0.2</a></li>
+                    <li><a href=" https://github.com/tokio-rs/mio ">mio 1.0.3</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014 Carl Lerche and other MIO contributors
 
@@ -7846,8 +8208,8 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/hyper ">hyper 0.14.31</a></li>
-                    <li><a href=" https://github.com/hyperium/hyper ">hyper 1.5.0</a></li>
+                    <li><a href=" https://github.com/hyperium/hyper ">hyper 0.14.32</a></li>
+                    <li><a href=" https://github.com/hyperium/hyper ">hyper 1.5.2</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014-2021 Sean McArthur
 
@@ -7936,7 +8298,7 @@ SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/hyperium/h2 ">h2 0.3.26</a></li>
-                    <li><a href=" https://github.com/hyperium/h2 ">h2 0.4.6</a></li>
+                    <li><a href=" https://github.com/hyperium/h2 ">h2 0.4.7</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2017 h2 authors
 
@@ -7969,7 +8331,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/bytes ">bytes 1.8.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/bytes ">bytes 1.9.0</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2018 Carl Lerche
 
@@ -8268,12 +8630,12 @@ DEALINGS IN THE SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/tokio-rs/tls ">tokio-native-tls 0.3.1</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-attributes 0.1.27</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-core 0.1.32</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-attributes 0.1.28</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-core 0.1.33</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-log 0.2.0</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-serde 0.1.3</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-subscriber 0.3.18</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing 0.1.40</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-serde 0.2.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-subscriber 0.3.19</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing 0.1.41</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2019 Tokio Contributors
 
@@ -8309,6 +8671,7 @@ DEALINGS IN THE SOFTWARE.
                     <li><a href=" https://github.com/tower-rs/tower ">tower-layer 0.3.3</a></li>
                     <li><a href=" https://github.com/tower-rs/tower ">tower-service 0.3.3</a></li>
                     <li><a href=" https://github.com/tower-rs/tower ">tower 0.4.13</a></li>
+                    <li><a href=" https://github.com/tower-rs/tower ">tower 0.5.2</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2019 Tower Contributors
 
@@ -8508,7 +8871,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/awslabs/aws-lambda-rust-runtime ">aws_lambda_events 0.15.1</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-lambda-rust-runtime ">aws_lambda_events 0.16.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -8628,7 +8991,6 @@ SOFTWARE.</pre>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/Nugine/simd ">base64-simd 0.8.0</a></li>
                     <li><a href=" https://github.com/danielhenrymantilla/rust-function_name ">function_name-proc-macro 0.3.0</a></li>
-                    <li><a href=" https://github.com/rust-lang/libm ">libm 0.2.11</a></li>
                     <li><a href=" https://github.com/Nugine/simd ">vsimd 0.8.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
@@ -8646,9 +9008,9 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-stream 0.1.16</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.12</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.41.1</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-stream 0.1.17</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.13</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.42.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -8763,7 +9125,7 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-core 0.1.32</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-core 0.1.33</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -9023,13 +9385,14 @@ THE SOFTWARE.
                     <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties_data 1.5.0</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">icu_provider 1.5.0</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">icu_provider_macros 1.5.0</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">litemap 0.7.3</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">litemap 0.7.4</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">tinystr 0.7.6</a></li>
+                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.14</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">writeable 0.5.5</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke-derive 0.7.4</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke 0.7.4</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom-derive 0.1.4</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom 0.1.4</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke-derive 0.7.5</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke 0.7.5</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom-derive 0.1.5</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom 0.1.5</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">zerovec-derive 0.10.3</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">zerovec 0.10.4</a></li>
                 </ul>
@@ -9075,40 +9438,10 @@ authorization of the copyright holder.
 </pre>
             </li>
             <li class="license">
-                <h3 id="Unicode-DFS-2016">Unicode License Agreement - Data Files and Software (2016)</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.13</a></li>
-                </ul>
-                <pre class="license-text">UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE
-
-Unicode Data Files include all data files under the directories http://www.unicode.org/Public/, http://www.unicode.org/reports/, http://www.unicode.org/cldr/data/, http://source.icu-project.org/repos/icu/, and http://www.unicode.org/utility/trac/browser/.
-
-Unicode Data Files do not include PDF online code charts under the directory http://www.unicode.org/Public/.
-
-Software includes any source code published in the Unicode Standard or under the directories http://www.unicode.org/Public/, http://www.unicode.org/reports/, http://www.unicode.org/cldr/data/, http://source.icu-project.org/repos/icu/, and http://www.unicode.org/utility/trac/browser/.
-
-NOTICE TO USER: Carefully read the following legal agreement. BY DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING UNICODE INC.&#x27;S DATA FILES (&quot;DATA FILES&quot;), AND/OR SOFTWARE (&quot;SOFTWARE&quot;), YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
-
-COPYRIGHT AND PERMISSION NOTICE
-
-Copyright © 1991-2016 Unicode, Inc. All rights reserved. Distributed under the Terms of Use in http://www.unicode.org/copyright.html.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of the Unicode data files and any associated documentation (the &quot;Data Files&quot;) or Unicode software and any associated documentation (the &quot;Software&quot;) to deal in the Data Files or Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, and/or sell copies of the Data Files or Software, and to permit persons to whom the Data Files or Software are furnished to do so, provided that either
-
-     (a) this copyright and permission notice appear with all copies of the Data Files or Software, or
-     (b) this copyright and permission notice appear in associated Documentation.
-
-THE DATA FILES AND SOFTWARE ARE PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA FILES OR SOFTWARE.
-
-Except as contained in this notice, the name of a copyright holder shall not be used in advertising or otherwise to promote the sale, use or other dealings in these Data Files or Software without prior written authorization of the copyright holder.
-</pre>
-            </li>
-            <li class="license">
                 <h3 id="Zlib">zlib License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/orlp/foldhash ">foldhash 0.1.3</a></li>
+                    <li><a href=" https://github.com/orlp/foldhash ">foldhash 0.1.4</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2024 Orson Peters
 


### PR DESCRIPTION
## What

This PR prepares the release of version `0.15.2` as per `RELEASE.md`.

## Why

We want a new release with the latest `aws_lambda_events` dependency.

