### PR TITLE
feat: Add `S3ObjectError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.16.0
+
+  - **Breaking change** Added `S3ObjectError`, which is now returned by all `S3Object` methods. Replaces the previous generic `anyhow::Error` return values.
+
 ## 0.15.6
 
   - Updated rust crate `typed-builder` to `0.22.0`.


### PR DESCRIPTION
## What

This PR adds a custom error type, `S3ObjectError`, to explicitly capture the potential errors generated by methods of `struct S3Object`.

## Why

This makes the API more explicit, and sets us up for more sophisticated error handling in features that are about to land.

## Notes

This is technically a breaking change, however it should have a very small impact, as the new error type can be trivially lifted into the previous `anyhow::Error` type.